### PR TITLE
fix(benchmarks): correct problem 2 result templates

### DIFF
--- a/benchmarks/problem2/scenario2/results/README.md
+++ b/benchmarks/problem2/scenario2/results/README.md
@@ -1,12 +1,13 @@
-# Scenario 1 results — how to measure and store
+# Scenario 2 results — how to measure and store
 
-Each completed Case 1 run MUST write one JSON file under this directory that conforms to the canonical harness schema:
+Each completed Case 2 run MUST write one JSON file under this directory that
+conforms to the canonical harness schema:
 
 - Schema: [metrics-v2.schema.json](../../metrics-v2.schema.json)
 - Example: [metrics-v2.example.json](../../metrics-v2.example.json)
 
 ```text
-benchmarks/scenario1/results/<run-id>.json
+benchmarks/problem2/scenario2/results/<run-id>.json
 ```
 
 Suggested `run-id` pattern:
@@ -19,29 +20,41 @@ Example: `20260717T180530Z-cursor-gpt5.json`
 
 Do not commit secrets. Token/cost values may be estimates when the tool only exposes approximate usage.
 
-The schema marks all fields optional; this scenario’s Gherkin feature requires **every** group and field to be populated for completed runs. See [scenario1.feature](../gherkin/scenario1.feature).
+The schema marks all fields optional; this scenario’s Gherkin feature requires
+**every** group and field to be populated for completed runs. See
+[scenario2.feature](../gherkin/scenario2.feature).
 
 ## Case-specific labels
 
-| Field | Value for Case 1 |
+| Field | Value for Case 2 |
 | --- | --- |
-| `protocol_labels.scenario` | `"scenario1"` |
-| `protocol_labels.case_id` | `"case-1-readme-only"` |
+| `protocol_labels.scenario` | `"scenario2"` |
+| `protocol_labels.case_id` | `"case-2-all-functional-requirements"` |
 
-Set `outcome_quality.acceptance_pass` to `true` only when the product happy path in `specs/functional-requirements/README.md` passes and this scenario’s setup constraints hold.
+Set `outcome_quality.acceptance_pass` to `true` only when both tagged scenarios
+in
+[`US-001_api_greek_gods_data_retrieval.feature`](../specs/functional-requirements/agile/US-001_api_greek_gods_data_retrieval.feature)
+pass and this scenario's setup constraints hold.
 
 ## Operator checklist (measure → store)
 
-1. Confirm Case 1 setup (README-only FR) before starting.
+1. Confirm the Case 2 full functional-requirements package and allowlist before
+   starting.
 2. Note `protocol_labels.commit`, `protocol_labels.tool`, `protocol_labels.model`, `protocol_labels.plinth_config`.
 3. Start timer (`efficiency.wall_clock_s`).
-4. Run the agent against `benchmarks/scenario1/demo/` using only the Case 1 README input.
+4. Run the agent against `benchmarks/problem2/scenario2/demo/` using only the
+   Case 2 allowlisted functional inputs.
 5. Track `outcome_quality.rework_turns` and optional `protocol_labels.human_intervention_min`.
 6. Stop timer when done; capture tokens, cost, and `plinth_usage` from the tool or operator tally.
 7. Set `outcome_quality.acceptance_pass` from product + harness checks.
-8. Capture `solution_snapshot` from `benchmarks/scenario1/demo/` before restore (for example `tree -a -I '.git' benchmarks/scenario1/demo/ | base64` for `tree_b64`, and `base64 < benchmarks/scenario1/demo/pom.xml` for `pom_xml_b64`) and set `solution_snapshot.file_count`.
-9. Write `benchmarks/scenario1/results/<run-id>.json` conforming to [metrics-v2.schema.json](../../metrics-v2.schema.json).
-10. Restore `benchmarks/scenario1/demo/` to empty (only `.gitkeep`).
+8. Capture `solution_snapshot` from `benchmarks/problem2/scenario2/demo/`
+   before restore, including the tree and `pom.xml` Base64 payloads, and set
+   `solution_snapshot.file_count`.
+9. Write `benchmarks/problem2/scenario2/results/<run-id>.json` conforming to
+   [metrics-v2.schema.json](../../metrics-v2.schema.json).
+10. Restore `benchmarks/problem2/scenario2/demo/` to empty (only `.gitkeep`).
 11. Rank later using [benchmarks/README.md](../../README.md) rules (`outcome_quality.acceptance_pass = true` only).
 
-See also: [scenario1.feature](../gherkin/scenario1.feature).
+See also:
+
+- [scenario2.feature](../gherkin/scenario2.feature)

--- a/benchmarks/problem2/scenario2/results/example.result.json
+++ b/benchmarks/problem2/scenario2/results/example.result.json
@@ -14,8 +14,8 @@
     "artifact_completeness": 0
   },
   "protocol_labels": {
-    "scenario": "scenario1",
-    "case_id": "case-1-readme-only",
+    "scenario": "scenario2",
+    "case_id": "case-2-all-functional-requirements",
     "tool": "cursor",
     "model": "replace-me",
     "plinth_config": "bare-agent",
@@ -32,7 +32,7 @@
     "agents": []
   },
   "solution_snapshot": {
-    "demo_root": "benchmarks/scenario1/demo/",
+    "demo_root": "benchmarks/problem2/scenario2/demo/",
     "tree_format": "unix-tree",
     "tree_encoding": "base64",
     "tree_b64": "",

--- a/benchmarks/problem2/scenario4/results/README.md
+++ b/benchmarks/problem2/scenario4/results/README.md
@@ -1,12 +1,13 @@
-# Scenario 1 results — how to measure and store
+# Scenario 4 results — how to measure and store
 
-Each completed Case 1 run MUST write one JSON file under this directory that conforms to the canonical harness schema:
+Each completed Case 4 run MUST write one JSON file under this directory that
+conforms to the canonical harness schema:
 
 - Schema: [metrics-v2.schema.json](../../metrics-v2.schema.json)
 - Example: [metrics-v2.example.json](../../metrics-v2.example.json)
 
 ```text
-benchmarks/scenario1/results/<run-id>.json
+benchmarks/problem2/scenario4/results/<run-id>.json
 ```
 
 Suggested `run-id` pattern:
@@ -19,29 +20,40 @@ Example: `20260717T180530Z-cursor-gpt5.json`
 
 Do not commit secrets. Token/cost values may be estimates when the tool only exposes approximate usage.
 
-The schema marks all fields optional; this scenario’s Gherkin feature requires **every** group and field to be populated for completed runs. See [scenario1.feature](../gherkin/scenario1.feature).
+The schema marks all fields optional; this scenario's Gherkin feature requires
+**every** group and field to be populated for completed runs. See
+[scenario4.feature](../gherkin/scenario4.feature).
 
 ## Case-specific labels
 
-| Field | Value for Case 1 |
+| Field | Value for Case 4 |
 | --- | --- |
 | `protocol_labels.scenario` | `"scenario4"` |
 | `protocol_labels.case_id` | `"case-4-current-openspec-problem2"` |
 
-Set `outcome_quality.acceptance_pass` to `true` only when the product happy path in `specs/functional-requirements/README.md` passes and this scenario’s setup constraints hold.
+Set `outcome_quality.acceptance_pass` to `true` only when the product
+acceptance checks and the Scenario 4 `/implement-spec` orchestration constraints
+hold.
 
 ## Operator checklist (measure → store)
 
-1. Confirm Case 1 setup (README-only FR) before starting.
+1. Confirm the Case 4 OpenSpec input and `/implement-spec` orchestration setup
+   before starting.
 2. Note `protocol_labels.commit`, `protocol_labels.tool`, `protocol_labels.model`, `protocol_labels.plinth_config`.
 3. Start timer (`efficiency.wall_clock_s`).
-4. Run the agent against `benchmarks/scenario1/demo/` using only the Case 1 README input.
+4. Run the agent against `benchmarks/problem2/scenario4/demo/` using only the
+   Case 4 allowlisted OpenSpec input.
 5. Track `outcome_quality.rework_turns` and optional `protocol_labels.human_intervention_min`.
 6. Stop timer when done; capture tokens, cost, and `plinth_usage` from the tool or operator tally.
 7. Set `outcome_quality.acceptance_pass` from product + harness checks.
-8. Capture `solution_snapshot` from `benchmarks/scenario1/demo/` before restore (for example `tree -a -I '.git' benchmarks/scenario1/demo/ | base64` for `tree_b64`, and `base64 < benchmarks/scenario1/demo/pom.xml` for `pom_xml_b64`) and set `solution_snapshot.file_count`.
-9. Write `benchmarks/scenario1/results/<run-id>.json` conforming to [metrics-v2.schema.json](../../metrics-v2.schema.json).
-10. Restore `benchmarks/scenario1/demo/` to empty (only `.gitkeep`).
+8. Capture `solution_snapshot` from `benchmarks/problem2/scenario4/demo/`
+   before restore, including the tree and `pom.xml` Base64 payloads, and set
+   `solution_snapshot.file_count`.
+9. Write `benchmarks/problem2/scenario4/results/<run-id>.json` conforming to
+   [metrics-v2.schema.json](../../metrics-v2.schema.json).
+10. Restore `benchmarks/problem2/scenario4/demo/` to empty (only `.gitkeep`).
 11. Rank later using [benchmarks/README.md](../../README.md) rules (`outcome_quality.acceptance_pass = true` only).
 
-See also: [scenario1.feature](../gherkin/scenario1.feature).
+See also:
+
+- [scenario4.feature](../gherkin/scenario4.feature)

--- a/benchmarks/problem2/scenario4/results/example.result.json
+++ b/benchmarks/problem2/scenario4/results/example.result.json
@@ -32,7 +32,7 @@
     "agents": []
   },
   "solution_snapshot": {
-    "demo_root": "benchmarks/scenario1/demo/",
+    "demo_root": "benchmarks/problem2/scenario4/demo/",
     "tree_format": "unix-tree",
     "tree_encoding": "base64",
     "tree_b64": "",

--- a/benchmarks/problem2/scenario5/results/README.md
+++ b/benchmarks/problem2/scenario5/results/README.md
@@ -1,12 +1,13 @@
-# Scenario 1 results — how to measure and store
+# Scenario 5 results — how to measure and store
 
-Each completed Case 1 run MUST write one JSON file under this directory that conforms to the canonical harness schema:
+Each completed Case 5 run MUST write one JSON file under this directory that
+conforms to the canonical harness schema:
 
 - Schema: [metrics-v2.schema.json](../../metrics-v2.schema.json)
 - Example: [metrics-v2.example.json](../../metrics-v2.example.json)
 
 ```text
-benchmarks/scenario1/results/<run-id>.json
+benchmarks/problem2/scenario5/results/<run-id>.json
 ```
 
 Suggested `run-id` pattern:
@@ -19,29 +20,38 @@ Example: `20260717T180530Z-cursor-gpt5.json`
 
 Do not commit secrets. Token/cost values may be estimates when the tool only exposes approximate usage.
 
-The schema marks all fields optional; this scenario’s Gherkin feature requires **every** group and field to be populated for completed runs. See [scenario1.feature](../gherkin/scenario1.feature).
+The schema marks all fields optional; this scenario's Gherkin feature requires
+**every** group and field to be populated for completed runs. See
+[scenario5.feature](../gherkin/scenario5.feature).
 
 ## Case-specific labels
 
-| Field | Value for Case 1 |
+| Field | Value for Case 5 |
 | --- | --- |
 | `protocol_labels.scenario` | `"scenario5"` |
 | `protocol_labels.case_id` | `"case-5-direct-openspec-problem2"` |
 
-Set `outcome_quality.acceptance_pass` to `true` only when the product happy path in `specs/functional-requirements/README.md` passes and this scenario’s setup constraints hold.
+Set `outcome_quality.acceptance_pass` to `true` only when the product
+acceptance checks and the Scenario 5 direct-implementation constraints hold.
 
 ## Operator checklist (measure → store)
 
-1. Confirm Case 1 setup (README-only FR) before starting.
+1. Confirm the Case 5 OpenSpec direct-implementation setup before starting.
 2. Note `protocol_labels.commit`, `protocol_labels.tool`, `protocol_labels.model`, `protocol_labels.plinth_config`.
 3. Start timer (`efficiency.wall_clock_s`).
-4. Run the agent against `benchmarks/scenario1/demo/` using only the Case 1 README input.
+4. Run the agent against `benchmarks/problem2/scenario5/demo/` using only the
+   Case 5 allowlisted OpenSpec input and without `/implement-spec`.
 5. Track `outcome_quality.rework_turns` and optional `protocol_labels.human_intervention_min`.
 6. Stop timer when done; capture tokens, cost, and `plinth_usage` from the tool or operator tally.
 7. Set `outcome_quality.acceptance_pass` from product + harness checks.
-8. Capture `solution_snapshot` from `benchmarks/scenario1/demo/` before restore (for example `tree -a -I '.git' benchmarks/scenario1/demo/ | base64` for `tree_b64`, and `base64 < benchmarks/scenario1/demo/pom.xml` for `pom_xml_b64`) and set `solution_snapshot.file_count`.
-9. Write `benchmarks/scenario1/results/<run-id>.json` conforming to [metrics-v2.schema.json](../../metrics-v2.schema.json).
-10. Restore `benchmarks/scenario1/demo/` to empty (only `.gitkeep`).
+8. Capture `solution_snapshot` from `benchmarks/problem2/scenario5/demo/`
+   before restore, including the tree and `pom.xml` Base64 payloads, and set
+   `solution_snapshot.file_count`.
+9. Write `benchmarks/problem2/scenario5/results/<run-id>.json` conforming to
+   [metrics-v2.schema.json](../../metrics-v2.schema.json).
+10. Restore `benchmarks/problem2/scenario5/demo/` to empty (only `.gitkeep`).
 11. Rank later using [benchmarks/README.md](../../README.md) rules (`outcome_quality.acceptance_pass = true` only).
 
-See also: [scenario1.feature](../gherkin/scenario1.feature).
+See also:
+
+- [scenario5.feature](../gherkin/scenario5.feature)

--- a/benchmarks/problem2/scenario5/results/example.result.json
+++ b/benchmarks/problem2/scenario5/results/example.result.json
@@ -32,7 +32,7 @@
     "agents": []
   },
   "solution_snapshot": {
-    "demo_root": "benchmarks/scenario1/demo/",
+    "demo_root": "benchmarks/problem2/scenario5/demo/",
     "tree_format": "unix-tree",
     "tree_encoding": "base64",
     "tree_b64": "",


### PR DESCRIPTION
## Summary

- correct the scenario 2, 4, and 5 result guides so each names its own case, inputs, paths, and acceptance conditions
- align the example result JSON files with the corresponding scenario labels and demo roots
- remove stale scenario 1 instructions inherited by the result templates

## Why

The three result directories contained copied scenario 1 metadata and paths. Following those templates would label benchmark runs incorrectly, capture the wrong demo directory, and direct operators to the wrong inputs.

## Impact

Benchmark operators now have scenario-specific instructions and valid result templates for problem 2 scenarios 2, 4, and 5. Runtime or generated release behavior is unchanged.

## Validation

- `jbang markdown-validator/src/main/java/info/jab/mv/MarkdownValidator.java .` — 370 documents, 0 errors
- JSON Schema validation with `ajv-cli` for all three changed `example.result.json` files
- verified every local link added or retained in the changed READMEs
- `git diff --cached --check`

Supports #1110
