### PR TITLE
docs(blog): add benchmark part 2 post on Plinth workflow hypotheses

### DIFF
--- a/docs/2/index.html
+++ b/docs/2/index.html
@@ -116,6 +116,38 @@
 <div class="posts-section">
 <h2 class="section-title"><i class="fa fa-rss"></i> Latest Posts</h2>
 <article class="post-preview">
+<h3 class="post-title"><a href="../blog/2026/07/why-do-i-need-to-use-the-parallel-change-pattern.html">Why Do I Need to Use the Parallel Change Pattern?</a></h3>
+
+<p class="post-meta">
+  <i class="fa fa-calendar-o"></i>
+  2026-07-04
+    &nbsp;
+    <i class="fa fa-pencil"></i>
+    MyRobot
+  <span class="blog-tags">
+    &nbsp;
+    <i class="fa fa-tags"></i>
+      <a href="../tags/blog.html">blog</a>
+      <a href="../tags/skills.html">skills</a>
+      <a href="../tags/agents.html">agents</a>
+      <a href="../tags/design.html">design</a>
+      <a href="../tags/software-engineering.html">software-engineering</a>
+      <a href="../tags/java.html">java</a>
+  </span>
+</p>
+
+<div class="post-entry-container">
+  <div class="post-entry">
+    The hidden risk in fast code generation
+AI coding tools are very good at producing a complete-looking change from a short request.
+That is useful when the change is local. It becomes risky when the change crosses compatibility boundaries: database schemas, public APIs, event contracts, configuration keys, command outputs, generated artifacts, or workflows consumed by other services.
+A human enginee...
+    <p></p>
+    <a href="../blog/2026/07/why-do-i-need-to-use-the-parallel-change-pattern.html" class="post-read-more">[Read More]</a>
+  </div>
+</div>
+</article>
+<article class="post-preview">
 <h3 class="post-title"><a href="../blog/2026/07/introduction-to-eu-regulations-part-ii.html">Introduction to EU regulations Part II</a></h3>
 
 <p class="post-meta">
@@ -234,36 +266,6 @@ Skills are executable guidance for AI agents. They can include instructions, ref
 That power is useful, but it also means a generated skill should not be treated as ordinary Markdown. A broken document can confuse an agent. A malformed ...
     <p></p>
     <a href="../blog/2026/06/skill-validators-pipeline.html" class="post-read-more">[Read More]</a>
-  </div>
-</div>
-</article>
-<article class="post-preview">
-<h3 class="post-title"><a href="../blog/2026/06/introduction-to-eu-regulations-part-i.html">Introduction to EU regulations Part I</a></h3>
-
-<p class="post-meta">
-  <i class="fa fa-calendar-o"></i>
-  2026-06-16
-    &nbsp;
-    <i class="fa fa-pencil"></i>
-    MyRobot
-  <span class="blog-tags">
-    &nbsp;
-    <i class="fa fa-tags"></i>
-      <a href="../tags/blog.html">blog</a>
-      <a href="../tags/skills.html">skills</a>
-      <a href="../tags/java.html">java</a>
-      <a href="../tags/regulations.html">regulations</a>
-      <a href="../tags/eu.html">eu</a>
-  </span>
-</p>
-
-<div class="post-entry-container">
-  <div class="post-entry">
-    Why this topic matters
-Modern Java Enterprise systems are no longer reviewed only for code quality, performance, and availability. Many systems now process personal data, call AI models, automate decisions, operate critical services, integrate with cloud providers, expose online platform workflows, or participate in digital markets.
-That means engineering teams need a practical way to translate reg...
-    <p></p>
-    <a href="../blog/2026/06/introduction-to-eu-regulations-part-i.html" class="post-read-more">[Read More]</a>
   </div>
 </div>
 </article>

--- a/docs/3/index.html
+++ b/docs/3/index.html
@@ -116,6 +116,36 @@
 <div class="posts-section">
 <h2 class="section-title"><i class="fa fa-rss"></i> Latest Posts</h2>
 <article class="post-preview">
+<h3 class="post-title"><a href="../blog/2026/06/introduction-to-eu-regulations-part-i.html">Introduction to EU regulations Part I</a></h3>
+
+<p class="post-meta">
+  <i class="fa fa-calendar-o"></i>
+  2026-06-16
+    &nbsp;
+    <i class="fa fa-pencil"></i>
+    MyRobot
+  <span class="blog-tags">
+    &nbsp;
+    <i class="fa fa-tags"></i>
+      <a href="../tags/blog.html">blog</a>
+      <a href="../tags/skills.html">skills</a>
+      <a href="../tags/java.html">java</a>
+      <a href="../tags/regulations.html">regulations</a>
+      <a href="../tags/eu.html">eu</a>
+  </span>
+</p>
+
+<div class="post-entry-container">
+  <div class="post-entry">
+    Why this topic matters
+Modern Java Enterprise systems are no longer reviewed only for code quality, performance, and availability. Many systems now process personal data, call AI models, automate decisions, operate critical services, integrate with cloud providers, expose online platform workflows, or participate in digital markets.
+That means engineering teams need a practical way to translate reg...
+    <p></p>
+    <a href="../blog/2026/06/introduction-to-eu-regulations-part-i.html" class="post-read-more">[Read More]</a>
+  </div>
+</div>
+</article>
+<article class="post-preview">
 <h3 class="post-title"><a href="../blog/2026/06/release-0.15.0.html">What&apos;s new in Cursor rules for Java 0.15.0?</a></h3>
 
 <p class="post-meta">
@@ -229,32 +259,6 @@ What's new in this release?
 In this release, the project introduc...
     <p></p>
     <a href="../blog/2026/03/release-0.12.0.html" class="post-read-more">[Read More]</a>
-  </div>
-</div>
-</article>
-<article class="post-preview">
-<h3 class="post-title"><a href="../blog/2025/11/the-tour-in-europe-2025-is-over.html">The European tour 2025 is over</a></h3>
-
-<p class="post-meta">
-  <i class="fa fa-calendar-o"></i>
-  2025-11-10
-    &nbsp;
-    <i class="fa fa-pencil"></i>
-    Juan Antonio Breña Moral
-  <span class="blog-tags">
-    &nbsp;
-    <i class="fa fa-tags"></i>
-      <a href="../tags/blog.html">blog</a>
-  </span>
-</p>
-
-<div class="post-entry-container">
-  <div class="post-entry">
-    Introduction
-Over the last few weeks, I had the privilege of sharing with the Java community a few ideas that could be very useful for Java Software engineers in their daily work or for organizations enhancing their pipelines.
-Using these lines, I would like to acknowledge Stephan Janssen from Devoxx, Luis Fabrício De Llamas from DevConverge, Christina Bergh from W-JAX and the entire Madrid JUG tea...
-    <p></p>
-    <a href="../blog/2025/11/the-tour-in-europe-2025-is-over.html" class="post-read-more">[Read More]</a>
   </div>
 </div>
 </article>

--- a/docs/4/index.html
+++ b/docs/4/index.html
@@ -116,6 +116,32 @@
 <div class="posts-section">
 <h2 class="section-title"><i class="fa fa-rss"></i> Latest Posts</h2>
 <article class="post-preview">
+<h3 class="post-title"><a href="../blog/2025/11/the-tour-in-europe-2025-is-over.html">The European tour 2025 is over</a></h3>
+
+<p class="post-meta">
+  <i class="fa fa-calendar-o"></i>
+  2025-11-10
+    &nbsp;
+    <i class="fa fa-pencil"></i>
+    Juan Antonio Breña Moral
+  <span class="blog-tags">
+    &nbsp;
+    <i class="fa fa-tags"></i>
+      <a href="../tags/blog.html">blog</a>
+  </span>
+</p>
+
+<div class="post-entry-container">
+  <div class="post-entry">
+    Introduction
+Over the last few weeks, I had the privilege of sharing with the Java community a few ideas that could be very useful for Java Software engineers in their daily work or for organizations enhancing their pipelines.
+Using these lines, I would like to acknowledge Stephan Janssen from Devoxx, Luis Fabrício De Llamas from DevConverge, Christina Bergh from W-JAX and the entire Madrid JUG tea...
+    <p></p>
+    <a href="../blog/2025/11/the-tour-in-europe-2025-is-over.html" class="post-read-more">[Read More]</a>
+  </div>
+</div>
+</article>
+<article class="post-preview">
 <h3 class="post-title"><a href="../blog/2025/09/release-0.11.0.html">What&apos;s new in Cursor rules for Java 0.11.0?</a></h3>
 
 <p class="post-meta">
@@ -226,34 +252,6 @@ Added a new rule about 127-java-functional-exception-handling
 Added Consultative Interaction Technique in the majority of R...
     <p></p>
     <a href="../blog/2025/07/release-0.9.0.html" class="post-read-more">[Read More]</a>
-  </div>
-</div>
-</article>
-<article class="post-preview">
-<h3 class="post-title"><a href="../blog/2025/07/prompt-quality-framework.html">The Three-Node Quality Framework for AI Prompts</a></h3>
-
-<p class="post-meta">
-  <i class="fa fa-calendar-o"></i>
-  2025-07-20
-    &nbsp;
-    <i class="fa fa-pencil"></i>
-    Juan Antonio Breña Moral
-  <span class="blog-tags">
-    &nbsp;
-    <i class="fa fa-tags"></i>
-      <a href="../tags/blog.html">blog</a>
-  </span>
-</p>
-
-<div class="post-entry-container">
-  <div class="post-entry">
-    Overview
-When designing AI prompts for complex tasks like code generation and software development, a structured quality framework ensures both comprehensive responses and safe execution. This document outlines the three-node quality framework that combines prerequisites, content structure, and ongoing safety measures.
-The Three Pillars
-1. constraints - Prerequisites &amp; Blocking Conditions
-Purpo...
-    <p></p>
-    <a href="../blog/2025/07/prompt-quality-framework.html" class="post-read-more">[Read More]</a>
   </div>
 </div>
 </article>

--- a/docs/5/index.html
+++ b/docs/5/index.html
@@ -116,6 +116,34 @@
 <div class="posts-section">
 <h2 class="section-title"><i class="fa fa-rss"></i> Latest Posts</h2>
 <article class="post-preview">
+<h3 class="post-title"><a href="../blog/2025/07/prompt-quality-framework.html">The Three-Node Quality Framework for AI Prompts</a></h3>
+
+<p class="post-meta">
+  <i class="fa fa-calendar-o"></i>
+  2025-07-20
+    &nbsp;
+    <i class="fa fa-pencil"></i>
+    Juan Antonio Breña Moral
+  <span class="blog-tags">
+    &nbsp;
+    <i class="fa fa-tags"></i>
+      <a href="../tags/blog.html">blog</a>
+  </span>
+</p>
+
+<div class="post-entry-container">
+  <div class="post-entry">
+    Overview
+When designing AI prompts for complex tasks like code generation and software development, a structured quality framework ensures both comprehensive responses and safe execution. This document outlines the three-node quality framework that combines prerequisites, content structure, and ongoing safety measures.
+The Three Pillars
+1. constraints - Prerequisites &amp; Blocking Conditions
+Purpo...
+    <p></p>
+    <a href="../blog/2025/07/prompt-quality-framework.html" class="post-read-more">[Read More]</a>
+  </div>
+</div>
+</article>
+<article class="post-preview">
 <h3 class="post-title"><a href="../blog/2025/07/release-0.8.0.html">What&apos;s new in Cursor rules for Java 0.8.0?</a></h3>
 
 <p class="post-meta">

--- a/docs/archive.html
+++ b/docs/archive.html
@@ -103,6 +103,10 @@
 <div class="container" role="main">
 <article class="post-preview">
 <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
+  <span class="list-group-item"><h4>2026-09</h4></span>
+<a href="blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.html" class="list-group-item">
+  05 - Validating hypotheses about Plinth workflow with a Benchmark Part 2
+</a>
   <span class="list-group-item"><h4>2026-08</h4></span>
 <a href="blog/2026/08/release-0.18.0.html" class="list-group-item">
   03 - What&apos;s new in Plinth 0.18.0?

--- a/docs/blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.html
+++ b/docs/blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.html
@@ -1,0 +1,400 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+  <title>Validating hypotheses about Plinth workflow with a Benchmark Part 2 - Plinth</title>
+  <meta name="author" content="" />
+  <meta name="description" content="">
+  <link rel="alternate" type="application/atom+xml" href="../../../feed.xml" title="Plinth"/>
+
+  <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css" />
+  <link rel="stylesheet" href="../../../css/bootstrap.min.css">
+  <link rel="stylesheet" href="../../../css/bootstrap-social.css" />
+  <link rel="stylesheet" href="../../../css/main.css" />
+
+  <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic" />
+  <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800" />
+
+  <link rel="stylesheet" href="../../../css/asciidoctor.css">
+  <link rel="stylesheet" href="../../../css/prettify.css">
+  <link rel="icon" type="image/png" href="../../../images/java-icon.png">
+</head>
+
+<body>
+<nav class="navbar navbar-default navbar-fixed-top navbar-custom">
+<div class="container-fluid">
+
+<div class="navbar-header">
+<button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#main-navbar">
+  <span class="sr-only">Toggle navigation</span>
+  <span class="icon-bar"></span>
+  <span class="icon-bar"></span>
+  <span class="icon-bar"></span>
+</button>
+<a class="navbar-brand" href="../../../index.html">Plinth</a>
+</div>
+
+<div class="collapse navbar-collapse" id="main-navbar">
+<ul class="nav navbar-nav navbar-right">
+  <li><a href="https://forms.gle/TpNXENjmu45wuXoi6" target="_blank">Share feedback</a></li>
+  <li class="navlinks-container">
+    <a class="navlinks-parent" href="javascript:void(0)">Conferences</a>
+    <div class="navlinks-children">
+      <a href="https://jabrena.github.io/plinth/dvbe26/index.html" target="_blank">Devoxx BE 2026</a>
+      <a href="https://jabrena.github.io/plinth/jcconf-2026/index.html" target="_blank">JCConf 2026</a>
+      <a href="https://jabrena.github.io/plinth/codemotion-madrid-2026/index.html" target="_blank">Codemotion Madrid 2026</a>
+      <a href="https://jabrena.github.io/plinth/dvbe25/index.html" target="_blank">Devoxx BE 2025</a>
+      <a href="https://jabrena.github.io/101-cursor/" target="_blank">WJAX-2025</a>
+    </div>
+  </li>
+  <li class="navlinks-container">
+    <a class="navlinks-parent" href="javascript:void(0)">Courses</a>
+    <div class="navlinks-children">
+      <a href="../../../courses/system-prompts-java/index.html">System prompts for Java</a>
+      <a href="../../../courses/java-generics/index.html">Java Generics</a>
+      <a href="../../../courses/profile-memory-leak/index.html">Memory Leak Profiling</a>
+    </div>
+  </li>
+  <li><a href="../../../archive.html">Archive</a></li>
+  <li><a href="https://jabrena-github-io.translate.goog/cursor-rules-java/?_x_tr_sl=en&_x_tr_tl=cn&_x_tr_hl=en-US&_x_tr_pto=wapp">Translate</a></li>
+</ul>
+</div>
+
+
+
+</div>
+</nav>
+
+
+
+<header class="header-section">
+
+
+<div class="intro-header no-img">
+<div class="container">
+<div class="row">
+<div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
+<div class="post-heading">
+<h1>Validating hypotheses about Plinth workflow with a Benchmark Part 2</h1>
+<span class="post-meta">
+  <i class="fa fa-calendar-o"></i>
+  2026-09-05
+    &nbsp;
+    <i class="fa fa-pencil"></i>
+    MyRobot
+</span>
+<span class="blog-tags">
+  &nbsp;
+  <i class="fa fa-tags"></i>
+    <a href="../../../tags/blog.html">blog</a>
+    <a href="../../../tags/agents.html">agents</a>
+    <a href="../../../tags/skills.html">skills</a>
+    <a href="../../../tags/openspec.html">openspec</a>
+    <a href="../../../tags/performance.html">performance</a>
+    <a href="../../../tags/java.html">java</a>
+</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+</header>
+
+
+<div class="container">
+<div class="row">
+<div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
+<article role="main" class="blog-post">
+<p>This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. <a href="https://jabrena.github.io/plinth/blog/2026/07/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-1.html">Part 1</a> built a <a href="https://github.com/jabrena/plinth/tree/main/benchmarks">benchmark</a> that hands the same problem to several agent tools under briefs of increasing structure, logs every run as a validated JSON record, and uses those records to test three hypotheses about whether richer workflows actually pay off. The benchmark tried to validate the followed Hyphoteses:</p>
+<ul>
+<li><strong>Hypothesis 1:</strong> Richer workflows reduce implementation rework.</li>
+<li><strong>Hypothesis 2:</strong> Delegation workflows encourage autonomous use of reusable skills.</li>
+<li><strong>Hypothesis 3:</strong> Written architectural decisions improve consistency.</li>
+</ul>
+<p>Part 1 ended with one scenario clearly ahead — but it could not say <em>why</em>, because that scenario changed two things at once: the OpenSpec plan and the orchestration command that executes it. Part 2 sets out to separate them. The goals here are concrete:</p>
+<ul>
+<li><strong>Isolate the command from the plan.</strong> A new <code>scenario5</code> runs the exact same OpenSpec technical plan as <code>scenario4</code>, implemented directly, with <code>/implement-spec</code> and its agents forbidden. <code>scenario4</code> vs <code>scenario5</code> is then a clean A/B: identical plan, orchestration the only variable.</li>
+<li><strong>Check whether the answer is problem-dependent.</strong> A second problem — a persistence-and-scheduling &quot;Greek Gods API&quot; — joins the original fan-out-and-sum one, so every finding can be read per problem.</li>
+<li><strong>Re-test all three hypotheses on a much larger dataset.</strong> The corpus has grown from 54 runs to 217 non-template records across two problems, five scenarios, four tools, and a spread of models, with outlier trimming applied consistently.</li>
+</ul>
+<h2>What is new in Part 2</h2>
+<p>Two additions to the harness:</p>
+<table>
+<thead>
+<tr><th>Addition</th><th>What it is</th></tr>
+</thead>
+<tbody>
+<tr><td><code>scenario5</code></td><td>The <strong>same</strong> OpenSpec technical plan as <code>scenario4</code> — same <code>specs/technical-requirements/openspec/</code> tree — implemented <strong>directly</strong>. <code>/implement-spec</code> is forbidden; there is no mandated agent or skill. Agents and skills are still <em>allowed</em> if the tool reaches for them on its own.</td></tr>
+<tr><td><a href="https://github.com/jabrena/plinth/tree/main/benchmarks/problem2">Problem 2</a></td><td>The <strong>Greek Gods API</strong> (<a href="https://github.com/jabrena/latency-problems/blob/master/docs/problem5/README.md">latency-problems Problem 5</a>): a REST API that periodically syncs a Greek-gods catalogue from a third-party service into a relational database via Flyway. It is a persistence-and-scheduling problem, not a pure fan-out-and-sum one.</td></tr>
+</tbody>
+</table>
+<p>So <code>scenario4</code> (<strong>S4</strong>, orchestrated) versus <code>scenario5</code> (<strong>S5</strong>, direct) is a clean A/B: identical plan, and the only difference is whether <code>/implement-spec</code> and its agents run. Doing this across two different problems shows whether the answer is problem-dependent.</p>
+<p>The dataset has also grown a lot — from the 54 runs in Part 1 to <strong>217 non-template result records</strong> across both problems, five scenarios, and tools including <code>cursor</code>, <code>codex</code>, <code>claude-code</code>, and <code>github-copilot</code> on a spread of models (Grok 4.5, GPT-5.x, Claude Sonnet 5 / Opus 5 / Fable 5, Composer).</p>
+<h3>How long the two problems actually take</h3>
+<p>Those fences come from the full per-problem wall-clock distribution — every scenario, tool, and model pooled together. It is worth looking at that distribution on its own, because it answers the question people ask before they ask anything about workflows: <em>how long is one of these runs?</em></p>
+<table>
+<thead>
+<tr><th>Problem</th><th>Positive timings</th><th>Q1</th><th>Median</th><th>Q3</th><th>IQR</th><th>Tukey upper fence</th><th>High outliers</th><th>Non-outlier range</th></tr>
+</thead>
+<tbody>
+<tr><td><strong>Problem 1</strong> (God Analysis)</td><td>117</td><td>307 s (5:07 min)</td><td>560 s (9:20 min)</td><td>1,003 s (16:43 min)</td><td>696 s</td><td>2,047 s (34:07 min)</td><td>7</td><td><strong>51–1,908 s</strong> (0:51–31:48 min)</td></tr>
+<tr><td><strong>Problem 2</strong> (Greek Gods)</td><td>98</td><td>366 s (6:06 min)</td><td>665 s (11:05 min)</td><td>1,400 s (23:20 min)</td><td>1,034 s</td><td>2,951 s (49:11 min)</td><td>2</td><td><strong>136–2,446 s</strong> (2:16–40:46 min)</td></tr>
+</tbody>
+</table>
+<p>Problem 2 is the harder job by every measure: its median run is about two minutes longer, its middle 50% of runs span <strong>6 to 23 minutes</strong> against Problem 1's 5 to 17, and its spread (IQR) is half as wide again. The persistence-plus-scheduling problem simply takes more building than the fan-out-and-sum one — a useful planning bound in its own right, independent of which workflow produced it. It also explains why the two Tukey fences land so far apart (<strong>2,047 s for Problem 1</strong>, <strong>2,951 s for Problem 2</strong>), and why a run that would be a clear outlier on Problem 1 can be an ordinary long run on Problem 2.</p>
+<p>After trimming, the current-workflow cohort (S4 = only <code>plinth-*</code> agents recorded; S5 = no legacy <code>robot-*</code> agent) is:</p>
+<table>
+<thead>
+<tr><th></th><th>Raw records</th><th>Wall-time outliers</th><th>Retained</th></tr>
+</thead>
+<tbody>
+<tr><td><strong>S4</strong> (orchestrated)</td><td>56</td><td>6</td><td><strong>50</strong></td></tr>
+<tr><td><strong>S5</strong> (direct)</td><td>71</td><td>3</td><td><strong>68</strong></td></tr>
+</tbody>
+</table>
+<h2>Hypothesis 1 revisited: does the command reduce rework once you already have the plan?</h2>
+<p>Here is the pooled, trimmed picture:</p>
+<table>
+<thead>
+<tr><th>Cohort</th><th>Runs</th><th>Pass rate</th><th>Avg rework turns</th><th>Zero-rework runs</th><th>Median wall time</th></tr>
+</thead>
+<tbody>
+<tr><td><strong>S4</strong> — <code>/implement-spec</code> + agents</td><td>50</td><td>49/50 (98%)</td><td><strong>0.76</strong></td><td>44%</td><td>15:52 min (952 s)</td></tr>
+<tr><td><strong>S5</strong> — direct implementation</td><td>68</td><td>65/68 (96%)</td><td>1.21</td><td>35%</td><td><strong>10:12 min</strong> (612 s)</td></tr>
+</tbody>
+</table>
+<p>On the pooled numbers S4 comes out ahead on every reliability column — higher pass rate, lower average rework, more zero-rework runs — while S5 is about <strong>36% faster by median wall time</strong>. That is a real trade-off, not a free win: the command costs you roughly a third of your wall-clock budget to buy a lower correction rate.</p>
+<p>But &quot;pooled&quot; hides an interaction, and the per-problem split is where it shows up:</p>
+<table>
+<thead>
+<tr><th>Problem</th><th>Cohort</th><th>Pass rate</th><th>Avg rework</th><th>Zero-rework</th><th>Median wall</th></tr>
+</thead>
+<tbody>
+<tr><td rowspan="2">Problem 1 (God Analysis)</td><td>S4</td><td>17/18</td><td><strong>0.78</strong></td><td>39%</td><td>14:32 min (872 s)</td></tr>
+<tr><td>S5</td><td>28/30</td><td>1.00</td><td><strong>50%</strong></td><td><strong>9:15 min</strong> (555 s)</td></tr>
+<tr><td rowspan="2">Problem 2 (Greek Gods)</td><td>S4</td><td><strong>32/32</strong></td><td><strong>0.75</strong></td><td><strong>47%</strong></td><td>18:11 min (1,091 s)</td></tr>
+<tr><td>S5</td><td>37/38</td><td>1.37</td><td>24%</td><td><strong>11:05 min</strong> (665 s)</td></tr>
+</tbody>
+</table>
+<p>On <strong>Problem 2</strong> — the database problem — S4 is cleanly better on reliability: a perfect 32/32 pass rate, roughly half the average rework, and double the zero-rework share. It also pays for it with a bigger latency premium here (median 1,091 s vs 665 s, about 64% slower).</p>
+<p>On <strong>Problem 1</strong>, the orchestration advantage mostly evaporates. Pass rates are within a run of each other, S5 has <em>more</em> zero-rework runs, and S5 is materially faster. S4 keeps a slight edge on average rework and nothing else.</p>
+<h3>It is also model-dependent</h3>
+<p>Breaking the trimmed cohort down by model family shows the rework advantage is not universal:</p>
+<table>
+<thead>
+<tr><th>Model family</th><th>Retained runs (S4 / S5)</th><th>What the data shows</th></tr>
+</thead>
+<tbody>
+<tr><td>Cursor Grok 4.5</td><td>19 / 20</td><td>Every run passes. S5 has <em>lower</em> rework (0.35 vs 0.68), more zero-rework runs (70% vs 32%), and is faster. A clean counterexample to a model-independent S4 benefit.</td></tr>
+<tr><td>Codex GPT-5.x</td><td>13 / 23</td><td>S4 13/13 pass at 1.15 rework; S5 22/23 at 2.04. S5 about 41% faster. Favours S4 on reliability, S5 on speed.</td></tr>
+<tr><td>Claude Sonnet 5</td><td>13 / 18</td><td>S4 12/13 pass, 0.62 rework, 62% zero-rework; S5 16/18, 1.11 rework, 28% zero-rework. S4-leaning on reliability; S5 only ~11% faster.</td></tr>
+</tbody>
+</table>
+<p><strong>Hypothesis 1 holds only as a conditional trade-off.</strong> Orchestration lowers the correction rate on Problem 2 and for Codex / Sonnet 5 / Fable — always at a latency cost. On Problem 1 and for the large Grok cohort, direct implementation matches or beats it.</p>
+<h2>Hypothesis 2 revisited: what actually makes an agent use your skills?</h2>
+<p>Part 1 showed <code>scenario4</code> runs pulling in far more of the skill/command/agent library than the sparser scenarios — but it could not tell whether that was the OpenSpec documents or the delegation wiring doing it. <code>scenario5</code> answers it directly, because it hands the tool the exact same OpenSpec plan with the delegation wiring removed.</p>
+<table>
+<thead>
+<tr><th>Cohort</th><th>Runs</th><th>Avg skills used</th><th>Avg agents used</th><th>Runs with zero agents</th></tr>
+</thead>
+<tbody>
+<tr><td><strong>S4</strong> (<code>/implement-spec</code>)</td><td>50</td><td><strong>14.2</strong></td><td><strong>2.00</strong></td><td>0 / 50</td></tr>
+<tr><td><strong>S5</strong> (direct, same plan)</td><td>68</td><td>6.0</td><td>0.26</td><td>51 / 68</td></tr>
+</tbody>
+</table>
+<p>Same plan, an order of magnitude less delegation. Every S4 run records exactly two agents (the tech-lead plus a framework coder); three quarters of S5 runs record <strong>no agent at all</strong>, and the skill count roughly halves. The documents do not trigger the machinery — the command does.</p>
+<p>Those pooled averages hide a wide spread by tool and model. Under S4 the delegation command forces the issue — every retained run logs exactly two agents whatever the tool — so the only thing left to vary is how many <em>skills</em> each run pulls in behind the command. Under S5, with nothing mandated, both numbers are the tool's own choice:</p>
+<table>
+<thead>
+<tr><th>Tool · model</th><th>S4 avg skills (runs)</th><th>S5 avg skills (runs)</th><th>S5 avg agents</th><th>S5 runs with ≥1 agent</th></tr>
+</thead>
+<tbody>
+<tr><td><code>codex</code> · GPT-5.x</td><td><strong>16.8</strong> (13)</td><td>7.4 (23)</td><td>0.00</td><td>0 / 23</td></tr>
+<tr><td><code>cursor</code> · Grok 4.5</td><td>13.2 (19)</td><td><strong>7.7</strong> (20)</td><td><strong>0.55</strong></td><td>11 / 20</td></tr>
+<tr><td><code>claude-code</code> · Sonnet 5</td><td>14.0 (13)</td><td>3.3 (18)</td><td>0.17</td><td>2 / 18</td></tr>
+</tbody>
+</table>
+<p>Two things stand out. First, <strong>self-directed skill use splits by tool, not by model family</strong>: left alone, <code>cursor</code> (Grok 4.5) and <code>codex</code> (GPT-5.x) reach for 7–8 skills a run, while every <code>claude-code</code> model settles around 3 — more than double on the Cursor/Codex side. Second, <strong>skills and agents are separate reflexes</strong>: <code>codex</code> pulls plenty of skills but never once spawns a sub-agent unprompted (0 / 23), whereas <code>cursor</code> with Grok delegates in about half its runs and <code>claude-code</code> with Fable every time on a tiny sample. The one- and two-run rows (Composer, Opus 5, Fable 5) are too thin to lean on; the Grok 4.5, GPT-5.x and Sonnet 5 rows carry the weight. All six S5 &quot;≥1 agent&quot; counts add up to the 17 self-directed-agent runs noted below.</p>
+<p>There is a caveat that keeps S5 from being a pure &quot;no-agent control&quot;: <strong>17 of 68</strong> retained S5 runs still reached for at least one agent on their own initiative (11 on Problem 1, 6 on Problem 2). So the contrast is really <em>mandated</em> full orchestration versus <em>optional</em> self-directed tool use, not orchestration versus nothing.</p>
+<p><strong>Hypothesis 2 is supported.</strong> Autonomous skill and agent use tracks the delegation command, not the richness of the specification the agent is handed.</p>
+<h2>Hypothesis 3 revisited: does the architecture survive without the command?</h2>
+<p>Part 1's finding was that the hexagonal scaffold in <code>scenario4</code> came from the written <code>design.md</code>, not from any tool's taste. If that is true, S5 should produce the same structure from the same plan — even with no orchestration.</p>
+<p>It does. Of the trimmed snapshots, <strong>an ArchUnit boundary test (<code>HexagonalArchitectureTest</code>) is present in 50/50 S4 runs and 67/68 S5 runs.</strong> The one exception is a single Codex S5 run that never wrote the test file.</p>
+<p>Holding the tool and commit constant (<code>cursor</code> / Grok 4.5, same Problem 2 commit), the S4 and S5 trees are near-identical — same ports-and-adapters split, same class names:</p>
+<p><strong>S4 — orchestrated (<code>/implement-spec</code>):</strong></p>
+<pre><code class="language-text">info/jab/ms/
+├── GreekGodsApplication.java
+├── adapter/
+│   ├── in/
+│   │   ├── rest/
+│   │   │   ├── GreekGodResource.java
+│   │   │   ├── ProblemDetails.java
+│   │   │   └── ProblemDetailsExceptionMapper.java
+│   │   └── scheduler/
+│   │       └── GodUpdater.java
+│   └── out/
+│       ├── http/
+│       │   ├── GodSourceRestClient.java
+│       │   └── RestGodSourceClient.java
+│       └── persistence/
+│           └── JdbcGreekGodRepository.java
+├── application/
+│   ├── GetGreekGodsUseCase.java
+│   ├── SynchronizeGreekGodsUseCase.java
+│   └── port/
+│       ├── in/  {QueryGreekGods, SynchronizeGreekGods}
+│       └── out/ {GodSourceClient, GreekGodRepository}
+└── domain/
+    └── GreekGod.java
+
+test/.../architecture/HexagonalArchitectureTest.java
+</code></pre>
+<p><strong>S5 — direct, same plan:</strong></p>
+<pre><code class="language-text">info/jab/ms/
+├── GreekGodsApplication.java
+├── adapter/
+│   ├── in/
+│   │   ├── rest/
+│   │   │   ├── GreekGodResource.java
+│   │   │   └── ProblemDetailsExceptionMapper.java
+│   │   └── scheduler/
+│   │       └── GodUpdater.java
+│   └── out/
+│       ├── http/
+│       │   ├── MyJsonServerApi.java
+│       │   └── RestGodSourceClient.java
+│       └── persistence/
+│           └── JdbcGreekGodRepository.java
+├── application/
+│   ├── GetGreekGodsUseCase.java
+│   ├── SynchronizeGreekGodsUseCase.java
+│   └── port/
+│       ├── in/  {QueryGreekGods, SynchronizeGreekGods}
+│       └── out/ {GodSourceClient, GreekGodRepository}
+└── domain/
+    └── GreekGod.java
+
+test/.../architecture/HexagonalArchitectureTest.java
+</code></pre>
+<p>The differences are cosmetic (a differently named HTTP client, a spare <code>ProblemDetails</code> record, where the acceptance tests are parked). The <code>adapter/in</code>, <code>adapter/out</code>, <code>application/port/{in,out}</code>, <code>domain</code> skeleton and the boundary test are identical — because they are spelled out in the OpenSpec input both scenarios receive.</p>
+<h3>A side check: how many test classes each run leaves behind</h3>
+<p>The boundary test is prescribed; the rest of the test suite is not. Every retained run's snapshot carries the full <code>src/</code> tree, so the test files each run wrote can be counted — and because the trees arrive in several <code>tree</code>/flat formats, this counts <strong>distinct <code>*Test</code> / <code>*IT</code> / <code>*AT</code> Java class names</strong> rather than reconstructing the directory layout. Setting aside the <code>HexagonalArchitectureTest</code>-style boundary test above (present in nearly every run of both cohorts), the test classes the implementer chose to add break down as:</p>
+<table>
+<thead>
+<tr><th>Problem</th><th>S4 — median (mean), runs</th><th>S5 — median (mean), runs</th></tr>
+</thead>
+<tbody>
+<tr><td><strong>Problem 1</strong> (God Analysis)</td><td>6 (6.4), n=18</td><td>5 (6.0), n=30</td></tr>
+<tr><td><strong>Problem 2</strong> (Greek Gods)</td><td><strong>5.5 (5.1)</strong>, n=32</td><td>4 (3.8), n=38</td></tr>
+<tr><td>Pooled</td><td>6 (5.6), n=50</td><td>4 (4.8), n=68</td></tr>
+</tbody>
+</table>
+<p>On <strong>Problem 1</strong> the two workflows land within half a test class of each other. On <strong>Problem 2</strong> the orchestrated runs carry about <strong>one extra test class apiece</strong> (median 5.5 vs 4, mean 5.1 vs 3.8) — the same problem where S4 also cut rework in half and hit a perfect pass rate. Counting the boundary test back in keeps the shape: 6.5 vs 5 median on Problem 2, 7 vs 6 on Problem 1. So orchestration's structural fingerprint is not in the <em>architecture</em> — that is contractual — but in a slightly thicker test layer on the harder problem.</p>
+<p>The usual caveat applies: this is <strong>file presence</strong>. A <code>*Test.java</code> in the tree is not proof it compiles, runs, or asserts anything — the single acceptance flag is still the only execution signal in the dataset.</p>
+<h3>Where orchestration does leave a fingerprint: the Maven build</h3>
+<p>Architecture is contractual, but the <code>pom.xml</code> is not fully specified, and that is where the two workflows differ — a little. Decoding and parsing every retained Problem 2 POM (all 70 are strict-Base64, well-formed XML, Java 25, and import the Quarkus BOM):</p>
+<table>
+<thead>
+<tr><th>POM property</th><th>S4 (32 POMs)</th><th>S5 (38 POMs)</th></tr>
+</thead>
+<tbody>
+<tr><td>Core REST / REST-client / PostgreSQL / Flyway / scheduler stack</td><td>32/32</td><td>38/38</td></tr>
+<tr><td>Complete, version-pinned four-plugin lifecycle</td><td><strong>28/32</strong></td><td>26/38</td></tr>
+<tr><td><code>quarkus</code> application packaging (rest are <code>jar</code>)</td><td>18/32</td><td>21/38</td></tr>
+<tr><td>SmallRye OpenAPI dependency</td><td>31/32</td><td>30/38</td></tr>
+<tr><td>ArchUnit dependency</td><td>32/32</td><td>37/38</td></tr>
+<tr><td>Native-build profile</td><td>15/32</td><td>18/38</td></tr>
+<tr><td>Custom repositories / multi-module</td><td>0/32</td><td>0/38</td></tr>
+<tr><td>Production / test / error-named Java files (means)</td><td>16.3 / 6.5 / 3.7</td><td>15.5 / 5.7 / 3.2</td></tr>
+</tbody>
+</table>
+<p>S4 pins the full Compiler / Surefire / Failsafe / Quarkus plugin set a bit more often (28/32 vs 26/38) and writes marginally more production and test files — a <strong>5–15% edge</strong>, not the large &quot;assurance surface&quot; gap an earlier read of the data suggested, and file presence still says nothing about whether those tests execute. On everything else the two are within a rounding error of each other. Packaging is a coin flip in <em>both</em> workflows: only about half of each cohort ships a <code>quarkus</code> application POM, the rest fall back to plain <code>jar</code>.</p>
+<p>The bigger story in the POMs is drift that neither workflow controls. Retained Quarkus platform versions span <strong>3.27.0 to 3.39.1</strong>, and same-commit S4/S5 pairs sometimes pick different platform versions. A recurring set of POMs declares both <code>quarkus-rest</code> and <code>quarkus-rest-jackson</code>, or adds <code>quarkus-agroal</code> next to a JDBC driver that already pulls it in; several mix <code>quarkus-junit</code> with the older <code>quarkus-junit5-*</code> coordinate family. None of that is caused by the workflow — it is the agents choosing dependencies run to run — but it is exactly the kind of variance a benchmark has to normalize before it can compare anything downstream.</p>
+<p><strong>Hypothesis 3 is supported, with a sharper conclusion than Part 1.</strong> Project shape — framework, layering, boundary test — is not an orchestration effect at all; it is a written-decision effect, reproduced just as reliably by direct implementation because the OpenSpec input prescribes it. Whatever value <code>/implement-spec</code> adds shows up in execution discipline and correction cycles, not in project structure.</p>
+<h2>Takeaways</h2>
+<p>Across two problems, five scenarios and 118 retained current-workflow runs, the S4-vs-S5 A/B is clean enough to say what <code>/implement-spec</code> does and does not buy once the OpenSpec plan already exists.</p>
+<p><strong>Hypothesis 1 — orchestration reduces rework beyond the written plan: conditionally supported.</strong><br />
+The command lowers the correction rate, but only where the work is hard. On Problem 2 — persistence, scheduling, a migration — S4 is unambiguously ahead: 32/32 pass, half the average rework (0.75 vs 1.37), double the zero-rework share (47% vs 24%), and about one extra test class per run. On Problem 1, the fan-out-and-sum task, the gap closes: pass rates tie, S5 posts <em>more</em> zero-rework runs (50% vs 39%), and S5 is faster. The price is charged whether or not the benefit shows up — S5 is ~36% faster by median wall time, and S4 produced wall-time outliers at more than twice the rate (6 of 56 vs 3 of 71). It is model-shaped too: clear help for Codex, Sonnet 5 and Fable, break-even or worse for the large Cursor/Grok cohort. Reach for <code>/implement-spec</code> on integration-heavy work, not by default.</p>
+<p><strong>Hypothesis 2 — the delegation command, not the specification, drives skill and agent use: supported.</strong><br />
+Given the identical <code>scenario4</code> plan with the orchestration stripped out, S5 runs use half the skills (6.0 vs 14.2) and almost no agents (0.26 vs 2.00 per run; 51 of 68 use none at all). Richer documents do not pull the library in — the command does. What the tools do unprompted splits by <em>tool</em>, not model family: <code>cursor</code>/Grok and <code>codex</code>/GPT-5.x self-invoke 7–8 skills a run while every <code>claude-code</code> model sits near 3, and <code>codex</code> never once spawns a sub-agent on its own. &quot;Will my skill get used&quot; today depends more on which tool is driving than on how the task is written.</p>
+<p><strong>Hypothesis 3 — written architecture holds regardless of who executes: supported, and narrower than Part 1 implied.</strong><br />
+The hexagonal scaffold and the ArchUnit boundary test appear in 67 of 68 direct runs, class-for-class identical to the orchestrated ones, because the OpenSpec input spells them out. Orchestration's only structural fingerprint is a slightly fuller Maven lifecycle (28/32 vs 26/38 pinning all four plugins) and ~5–15% more source and test files — not architecture. What <em>neither</em> workflow controls is the dependency graph: Quarkus platform versions from 3.27.0 to 3.39.1, an H2 test driver in roughly half the POMs either way, redundant <code>quarkus-rest*</code> / <code>quarkus-agroal</code> declarations, mixed JUnit coordinates, and a <code>jar</code>-vs-<code>quarkus</code> packaging coin flip in both cohorts.</p>
+<p><strong>The load-bearing caveat.</strong> Every number here rests on file presence plus a single pass/fail flag. A <code>*Test.java</code> in the tree is not a test that compiles, runs, or asserts anything, and <code>mvn verify</code> output is never captured. Until that closes, &quot;less rework&quot; means &quot;the acceptance check went green in fewer turns&quot;, not &quot;the code is more correct&quot;.</p>
+<h2>Next steps</h2>
+<p>The data points at a handful of concrete changes to <code>/implement-spec</code>, each tied to a finding above:</p>
+<ol>
+<li><strong>Cut the latency — scale orchestration to the task.</strong> The full tech-lead + framework-coder fan-out runs on every task, but the rework payoff only lands on the integration-heavy problem; on Problem 1 it buys nothing and still costs ~36% more wall time and more than twice the wall-time-outlier rate. Grade the task up front — integration count, persistence, migrations, concurrency, external services — and run the full fan-out only above a threshold. Below it, a single implementation pass plus one verification checkpoint should match it for far less time.</li>
+<li><strong>Find and keep only the active ingredient.</strong> An S4 run pulls ~14 skills and 2 agents; the correction-rate benefit may come from a single verification pass. Log which sub-step fired and what each one caught, then drop — or background — the steps that never move rework.</li>
+</ol>
+<h2>Share your insights</h2>
+<p>Share findings or raise questions about the harness itself on <a href="https://github.com/jabrena/plinth/discussions">GitHub Discussions</a>.</p>
+
+</article>
+</div>
+</div>
+</div>
+
+<footer>
+<div class="container beautiful-jekyll-footer">
+<div class="row">
+<div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
+<ul class="list-inline text-center footer-links">
+    <li>
+    <a href="https://twitter.com/juanantoniobm" title="Twitter">
+      <span class="fa-stack fa-lg">
+        <i class="fa fa-circle fa-stack-2x"></i>
+        <i class="fa fa-twitter fa-stack-1x fa-inverse"></i>
+      </span>
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/jabrena/plinth" title="GitHub">
+      <span class="fa-stack fa-lg">
+        <i class="fa fa-circle fa-stack-2x"></i>
+        <i class="fa fa-github fa-stack-1x fa-inverse"></i>
+      </span>
+    </a>
+  </li>
+  <li>
+    <a href="../../../feed.xml" title="RSS">
+      <span class="fa-stack fa-lg">
+        <i class="fa fa-circle fa-stack-2x"></i>
+        <i class="fa fa-rss fa-stack-1x fa-inverse"></i>
+      </span>
+    </a>
+  </li>
+</ul>
+<p class="copyright text-muted">
+&copy; Juan Antonio Breña Moral, 2026 |
+Baked with <a href="http://jbake.org">JBake v2.7.0</a>
+</p>
+<p class="theme-by text-muted">
+  Theme by <a href="https://github.com/Yamane/beautiful-jbake/" target="_blank">beautiful-jbake</a>
+  adapted from <a href="http://deanattali.com/beautiful-jekyll/" target="_blank">beautiful-jekyll</a>
+</p>
+</div>
+</div>
+</div>
+</footer>
+
+<script src="../../../js/jquery-1.11.2.min.js"></script>
+<script src="../../../js/bootstrap.min.js"></script>
+<script src="../../../js/prettify.js"></script>
+<script src="../../../js/run_prettify.js"></script>
+<script src="../../../js/main.js"></script>
+
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-13CV90H4J4"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-13CV90H4J4');
+</script>
+
+</body>
+</html>

--- a/docs/blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.html
+++ b/docs/blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.html
@@ -108,30 +108,53 @@
 <div class="row">
 <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
 <article role="main" class="blog-post">
-<p>This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. <a href="https://jabrena.github.io/plinth/blog/2026/07/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-1.html">Part 1</a> built a <a href="https://github.com/jabrena/plinth/tree/main/benchmarks">benchmark</a> that hands the same problem to several agent tools under briefs of increasing structure, logs every run as a validated JSON record, and uses those records to test three hypotheses about whether richer workflows actually pay off. The benchmark tried to validate the followed Hyphoteses:</p>
+<p>This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. In <a href="https://jabrena.github.io/plinth/blog/2026/07/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-1.html">Part 1</a> article, it showed the <a href="https://github.com/jabrena/plinth/tree/main/benchmarks">benchmark</a> results around 4 scenarios:</p>
+<table>
+<thead>
+<tr><th>Scenario</th><th>What the agent gets</th></tr>
+</thead>
+<tbody>
+<tr><td><code>scenario1</code></td><td>A minimal README only — baseline, sparsest possible brief</td></tr>
+<tr><td><code>scenario2</code></td><td>A full functional-requirements package: user story, Gherkin, OpenAPI, ADRs</td></tr>
+<tr><td><code>scenario3</code></td><td>An OpenSpec change created by the official <a href="https://www.skills.sh/fission-ai/openspec/openspec-propose"><code>openspec-propose</code></a> skill using as input the same functional requirements from scenario 2.</td></tr>
+<tr><td><code>scenario4</code></td><td>An OpenSpec change created by the Plinth skill <code>/create-spec</code> and enriched with <code>/explore-design</code> and finally implemented via <code>/implement-spec</code>.</td></tr>
+</tbody>
+</table>
+<p>The benchmark tried to validate the followed Hyphoteses:</p>
 <ul>
 <li><strong>Hypothesis 1:</strong> Richer workflows reduce implementation rework.</li>
 <li><strong>Hypothesis 2:</strong> Delegation workflows encourage autonomous use of reusable skills.</li>
 <li><strong>Hypothesis 3:</strong> Written architectural decisions improve consistency.</li>
 </ul>
-<p>Part 1 ended with one scenario clearly ahead — but it could not say <em>why</em>, because that scenario changed two things at once: the OpenSpec plan and the orchestration command that executes it. Part 2 sets out to separate them. The goals here are concrete:</p>
+<p>Part 1 ended with a clear result — implementing a problem from a written specification pays off — and one scenario clearly ahead of the rest. But it could not say <em>why</em> that scenario won, because it changed two things at once: the OpenSpec plan and the orchestration command that executes it. Part 2 sets out to separate them. The goals here are concrete:</p>
 <ul>
 <li><strong>Isolate the command from the plan.</strong> A new <code>scenario5</code> runs the exact same OpenSpec technical plan as <code>scenario4</code>, implemented directly, with <code>/implement-spec</code> and its agents forbidden. <code>scenario4</code> vs <code>scenario5</code> is then a clean A/B: identical plan, orchestration the only variable.</li>
 <li><strong>Check whether the answer is problem-dependent.</strong> A second problem — a persistence-and-scheduling &quot;Greek Gods API&quot; — joins the original fan-out-and-sum one, so every finding can be read per problem.</li>
 <li><strong>Re-test all three hypotheses on a much larger dataset.</strong> The corpus has grown from 54 runs to 217 non-template records across two problems, five scenarios, four tools, and a spread of models, with outlier trimming applied consistently.</li>
 </ul>
 <h2>What is new in Part 2</h2>
-<p>Two additions to the harness:</p>
+<p>Two additions to the harness: a new scenario, and a second problem.</p>
+<p><strong>The two scenarios under comparison:</strong></p>
 <table>
 <thead>
-<tr><th>Addition</th><th>What it is</th></tr>
+<tr><th>Scenario</th><th>How the plan is implemented</th></tr>
 </thead>
 <tbody>
-<tr><td><code>scenario5</code></td><td>The <strong>same</strong> OpenSpec technical plan as <code>scenario4</code> — same <code>specs/technical-requirements/openspec/</code> tree — implemented <strong>directly</strong>. <code>/implement-spec</code> is forbidden; there is no mandated agent or skill. Agents and skills are still <em>allowed</em> if the tool reaches for them on its own.</td></tr>
-<tr><td><a href="https://github.com/jabrena/plinth/tree/main/benchmarks/problem2">Problem 2</a></td><td>The <strong>Greek Gods API</strong> (<a href="https://github.com/jabrena/latency-problems/blob/master/docs/problem5/README.md">latency-problems Problem 5</a>): a REST API that periodically syncs a Greek-gods catalogue from a third-party service into a relational database via Flyway. It is a persistence-and-scheduling problem, not a pure fan-out-and-sum one.</td></tr>
+<tr><td><code>scenario4</code> (<strong>S4</strong>, orchestrated)</td><td>The OpenSpec technical plan from <code>/create-spec</code> + <code>/explore-design</code>, implemented through <code>/implement-spec</code> — which delegates to <code>@plinth-tech-lead</code> and a framework-specific coder agent. Full orchestration is <strong>mandated</strong>.</td></tr>
+<tr><td><code>scenario5</code> (<strong>S5</strong>, direct)</td><td>The <strong>same</strong> OpenSpec technical plan as <code>scenario4</code> — same <code>specs/technical-requirements/openspec/</code> tree — implemented <strong>directly</strong>. <code>/implement-spec</code> is forbidden; there is no mandated agent or skill. Agents and skills are still <em>allowed</em> if the tool reaches for them on its own.</td></tr>
 </tbody>
 </table>
-<p>So <code>scenario4</code> (<strong>S4</strong>, orchestrated) versus <code>scenario5</code> (<strong>S5</strong>, direct) is a clean A/B: identical plan, and the only difference is whether <code>/implement-spec</code> and its agents run. Doing this across two different problems shows whether the answer is problem-dependent.</p>
+<p><strong>The two problems the A/B runs on:</strong></p>
+<table>
+<thead>
+<tr><th>Problem</th><th>What it is</th></tr>
+</thead>
+<tbody>
+<tr><td><a href="https://github.com/jabrena/plinth/tree/main/benchmarks/problem1">Problem 1</a> — God Analysis API</td><td>The original benchmark problem (<a href="https://github.com/jabrena/latency-problems/blob/master/docs/problem1/README.md">latency-problems Problem 1</a>): a REST API that fans out to a third-party service and aggregates the results. A pure <strong>fan-out-and-sum</strong> problem, carried over from Part 1.</td></tr>
+<tr><td><a href="https://github.com/jabrena/plinth/tree/main/benchmarks/problem2">Problem 2</a> — Greek Gods API</td><td>New in Part 2 (<a href="https://github.com/jabrena/latency-problems/blob/master/docs/problem5/README.md">latency-problems Problem 5</a>): a REST API that periodically syncs a Greek-gods catalogue from a third-party service into a relational database via Flyway. A <strong>persistence-and-scheduling</strong> problem, not a pure fan-out-and-sum one.</td></tr>
+</tbody>
+</table>
+<p>So <code>scenario4</code> (<strong>S4</strong>, orchestrated) versus <code>scenario5</code> (<strong>S5</strong>, direct) is a clean A/B: identical plan, and the only difference is whether <code>/implement-spec</code> and its agents run. Running that A/B across both problems shows whether the answer is problem-dependent.</p>
 <p>The dataset has also grown a lot — from the 54 runs in Part 1 to <strong>217 non-template result records</strong> across both problems, five scenarios, and tools including <code>cursor</code>, <code>codex</code>, <code>claude-code</code>, and <code>github-copilot</code> on a spread of models (Grok 4.5, GPT-5.x, Claude Sonnet 5 / Opus 5 / Fable 5, Composer).</p>
 <h3>How long the two problems actually take</h3>
 <p>Those fences come from the full per-problem wall-clock distribution — every scenario, tool, and model pooled together. It is worth looking at that distribution on its own, because it answers the question people ask before they ask anything about workflows: <em>how long is one of these runs?</em></p>
@@ -145,16 +168,6 @@
 </tbody>
 </table>
 <p>Problem 2 is the harder job by every measure: its median run is about two minutes longer, its middle 50% of runs span <strong>6 to 23 minutes</strong> against Problem 1's 5 to 17, and its spread (IQR) is half as wide again. The persistence-plus-scheduling problem simply takes more building than the fan-out-and-sum one — a useful planning bound in its own right, independent of which workflow produced it. It also explains why the two Tukey fences land so far apart (<strong>2,047 s for Problem 1</strong>, <strong>2,951 s for Problem 2</strong>), and why a run that would be a clear outlier on Problem 1 can be an ordinary long run on Problem 2.</p>
-<p>After trimming, the current-workflow cohort (S4 = only <code>plinth-*</code> agents recorded; S5 = no legacy <code>robot-*</code> agent) is:</p>
-<table>
-<thead>
-<tr><th></th><th>Raw records</th><th>Wall-time outliers</th><th>Retained</th></tr>
-</thead>
-<tbody>
-<tr><td><strong>S4</strong> (orchestrated)</td><td>56</td><td>6</td><td><strong>50</strong></td></tr>
-<tr><td><strong>S5</strong> (direct)</td><td>71</td><td>3</td><td><strong>68</strong></td></tr>
-</tbody>
-</table>
 <h2>Hypothesis 1 revisited: does the command reduce rework once you already have the plan?</h2>
 <p>Here is the pooled, trimmed picture:</p>
 <table>
@@ -219,6 +232,79 @@
 </table>
 <p>Two things stand out. First, <strong>self-directed skill use splits by tool, not by model family</strong>: left alone, <code>cursor</code> (Grok 4.5) and <code>codex</code> (GPT-5.x) reach for 7–8 skills a run, while every <code>claude-code</code> model settles around 3 — more than double on the Cursor/Codex side. Second, <strong>skills and agents are separate reflexes</strong>: <code>codex</code> pulls plenty of skills but never once spawns a sub-agent unprompted (0 / 23), whereas <code>cursor</code> with Grok delegates in about half its runs and <code>claude-code</code> with Fable every time on a tiny sample. The one- and two-run rows (Composer, Opus 5, Fable 5) are too thin to lean on; the Grok 4.5, GPT-5.x and Sonnet 5 rows carry the weight. All six S5 &quot;≥1 agent&quot; counts add up to the 17 self-directed-agent runs noted below.</p>
 <p>There is a caveat that keeps S5 from being a pure &quot;no-agent control&quot;: <strong>17 of 68</strong> retained S5 runs still reached for at least one agent on their own initiative (11 on Problem 1, 6 on Problem 2). So the contrast is really <em>mandated</em> full orchestration versus <em>optional</em> self-directed tool use, not orchestration versus nothing.</p>
+<h3>Which skills get pulled in, per problem</h3>
+<p>The pooled &quot;6.0 vs 14.2&quot; gap has a specific shape once it is split by problem and the skills are lined up by how often they appear. Each table counts <strong>retained runs that pulled the skill in at least once</strong> — the JSON records skills as a per-run set, so this is run frequency, not invocation count — sorted by the combined S4 + S5 total. The cohorts are the same trimmed ones used everywhere else in this section.</p>
+<p><strong>Problem 1 — God Analysis API (Spring Boot).</strong> S4 <code>n = 18</code>, S5 <code>n = 30</code>.</p>
+<table>
+<thead>
+<tr><th>Skill</th><th>S4 runs</th><th>S5 runs</th><th>Total</th></tr>
+</thead>
+<tbody>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/300-frameworks-spring-boot-create-project"><code>300-frameworks-spring-boot-create-project</code></a></td><td>17</td><td>23</td><td>40</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/302-frameworks-spring-boot-rest"><code>302-frameworks-spring-boot-rest</code></a></td><td>17</td><td>20</td><td>37</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/707-technologies-hexagonal-architecture"><code>707-technologies-hexagonal-architecture</code></a></td><td>13</td><td>24</td><td>37</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/323-frameworks-spring-boot-testing-acceptance-tests"><code>323-frameworks-spring-boot-testing-acceptance-tests</code></a></td><td>16</td><td>19</td><td>35</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/322-frameworks-spring-boot-testing-integration-tests"><code>322-frameworks-spring-boot-testing-integration-tests</code></a></td><td>15</td><td>17</td><td>32</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/702-technologies-wiremock"><code>702-technologies-wiremock</code></a></td><td>16</td><td>15</td><td>31</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/301-frameworks-spring-boot-core"><code>301-frameworks-spring-boot-core</code></a></td><td>16</td><td>13</td><td>29</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/321-frameworks-spring-boot-testing-unit-tests"><code>321-frameworks-spring-boot-testing-unit-tests</code></a></td><td>15</td><td>12</td><td>27</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/042-planning-openspec"><code>042-planning-openspec</code></a></td><td><strong>18</strong></td><td>6</td><td>24</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/125-java-concurrency"><code>125-java-concurrency</code></a></td><td>9</td><td>10</td><td>19</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/701-technologies-openapi"><code>701-technologies-openapi</code></a></td><td><strong>16</strong></td><td>3</td><td>19</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/303-frameworks-spring-boot-validation"><code>303-frameworks-spring-boot-validation</code></a></td><td>12</td><td>6</td><td>18</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/124-java-secure-coding"><code>124-java-secure-coding</code></a></td><td><strong>14</strong></td><td>1</td><td>15</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/126-java-exception-handling"><code>126-java-exception-handling</code></a></td><td>10</td><td>1</td><td>11</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/111-java-maven-dependencies"><code>111-java-maven-dependencies</code></a></td><td>3</td><td><strong>7</strong></td><td>10</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/122-java-type-design"><code>122-java-type-design</code></a></td><td>8</td><td>1</td><td>9</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/051-design-two-steps-methods"><code>051-design-two-steps-methods</code></a></td><td>4</td><td>3</td><td>7</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/110-java-maven-best-practices"><code>110-java-maven-best-practices</code></a></td><td>4</td><td>3</td><td>7</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/181-java-observability-logging"><code>181-java-observability-logging</code></a></td><td>7</td><td>0</td><td>7</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/054-design-tdd"><code>054-design-tdd</code></a></td><td>4</td><td>2</td><td>6</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/121-java-object-oriented-design"><code>121-java-object-oriented-design</code></a></td><td>6</td><td>0</td><td>6</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/130-java-testing-strategies"><code>130-java-testing-strategies</code></a></td><td>5</td><td>1</td><td>6</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/133-java-testing-acceptance-tests"><code>133-java-testing-acceptance-tests</code></a></td><td>0</td><td>6</td><td>6</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/112-java-maven-plugins"><code>112-java-maven-plugins</code></a></td><td>2</td><td>1</td><td>3</td></tr>
+<tr><td colspan="4"><em>tail (total ≤ 2): <a href="https://www.skills.sh/jabrena/plinth/143-java-functional-exception-handling"><code>143-java-functional-exception-handling</code></a> (2/0), <a href="https://www.skills.sh/jabrena/plinth/142-java-functional-programming"><code>142-java-functional-programming</code></a> (1/0), <a href="https://www.skills.sh/jabrena/plinth/052-design-hamburger-method"><code>052-design-hamburger-method</code></a> (1/0), <a href="https://www.skills.sh/jabrena/plinth/131-java-testing-unit-testing"><code>131-java-testing-unit-testing</code></a> (0/1), <a href="https://www.skills.sh/jabrena/plinth/132-java-testing-integration-testing"><code>132-java-testing-integration-testing</code></a> (0/1)</em></td></tr>
+</tbody>
+</table>
+<p>The framework scaffold sits at the top and is used heavily by <em>both</em> cohorts — <code>create-project</code> (17/18 vs 23/30), <code>-rest</code>, the three <code>-testing-</code> skills, <code>wiremock</code> — because the OpenSpec plan names those technologies directly, so a direct implementer walks into them anyway. <code>707-…-hexagonal-architecture</code> is actually <em>more</em> common under S5 (24/30) than S4 (13/18): it is written into <code>design.md</code>, and the S4 tech-lead does not always re-log it.</p>
+<p>The divergence is entirely in the cross-cutting discipline skills. <code>042-planning-openspec</code> goes 18/18 → 6/30; <code>701-…-openapi</code> 16 → 3, <code>124-java-secure-coding</code> 14 → 1, <code>126-java-exception-handling</code> 10 → 1, <code>122-java-type-design</code> 8 → 1, <code>181-java-observability-logging</code> 7 → 0, <code>121-java-object-oriented-design</code> 6 → 0. The only skill S5 reaches for <em>more</em> than S4 is <code>111-java-maven-dependencies</code> (3 → 7) — implementing directly, the tool edits the POM itself instead of delegating it — and S5 grabs the generic <code>133-java-testing-acceptance-tests</code> (0 → 6) where S4 uses the Spring-specific <code>323-…</code>.</p>
+<p><strong>Problem 2 — Greek Gods API (Quarkus, persistence + scheduling).</strong> S4 <code>n = 32</code>, S5 <code>n = 38</code>.</p>
+<table>
+<thead>
+<tr><th>Skill</th><th>S4 runs</th><th>S5 runs</th><th>Total</th></tr>
+</thead>
+<tbody>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/707-technologies-hexagonal-architecture"><code>707-technologies-hexagonal-architecture</code></a></td><td>32</td><td>36</td><td>68</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/400-frameworks-quarkus-create-project"><code>400-frameworks-quarkus-create-project</code></a></td><td>30</td><td>29</td><td>59</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/423-frameworks-quarkus-testing-acceptance-tests"><code>423-frameworks-quarkus-testing-acceptance-tests</code></a></td><td>31</td><td>23</td><td>54</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/413-frameworks-quarkus-db-migrations-flyway"><code>413-frameworks-quarkus-db-migrations-flyway</code></a></td><td><strong>32</strong></td><td>21</td><td>53</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/411-frameworks-quarkus-jdbc"><code>411-frameworks-quarkus-jdbc</code></a></td><td>31</td><td>21</td><td>52</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/402-frameworks-quarkus-rest"><code>402-frameworks-quarkus-rest</code></a></td><td>31</td><td>19</td><td>50</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/401-frameworks-quarkus-core"><code>401-frameworks-quarkus-core</code></a></td><td>31</td><td>15</td><td>46</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/421-frameworks-quarkus-testing-unit-tests"><code>421-frameworks-quarkus-testing-unit-tests</code></a></td><td>31</td><td>10</td><td>41</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/042-planning-openspec"><code>042-planning-openspec</code></a></td><td><strong>32</strong></td><td>2</td><td>34</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/701-technologies-openapi"><code>701-technologies-openapi</code></a></td><td><strong>30</strong></td><td>3</td><td>33</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/704-technologies-sql"><code>704-technologies-sql</code></a></td><td><strong>26</strong></td><td>1</td><td>27</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/422-frameworks-quarkus-testing-integration-tests"><code>422-frameworks-quarkus-testing-integration-tests</code></a></td><td>19</td><td>7</td><td>26</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/126-java-exception-handling"><code>126-java-exception-handling</code></a></td><td><strong>20</strong></td><td>1</td><td>21</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/124-java-secure-coding"><code>124-java-secure-coding</code></a></td><td><strong>19</strong></td><td>0</td><td>19</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/111-java-maven-dependencies"><code>111-java-maven-dependencies</code></a></td><td>4</td><td><strong>13</strong></td><td>17</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/054-design-tdd"><code>054-design-tdd</code></a></td><td>13</td><td>0</td><td>13</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/133-java-testing-acceptance-tests"><code>133-java-testing-acceptance-tests</code></a></td><td>3</td><td>10</td><td>13</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/122-java-type-design"><code>122-java-type-design</code></a></td><td>11</td><td>0</td><td>11</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/121-java-object-oriented-design"><code>121-java-object-oriented-design</code></a></td><td>8</td><td>0</td><td>8</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/130-java-testing-strategies"><code>130-java-testing-strategies</code></a></td><td>8</td><td>0</td><td>8</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/123-java-design-patterns"><code>123-java-design-patterns</code></a></td><td>5</td><td>0</td><td>5</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/143-java-functional-exception-handling"><code>143-java-functional-exception-handling</code></a></td><td>4</td><td>0</td><td>4</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/110-java-maven-best-practices"><code>110-java-maven-best-practices</code></a></td><td>3</td><td>0</td><td>3</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/181-java-observability-logging"><code>181-java-observability-logging</code></a></td><td>3</td><td>0</td><td>3</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/702-technologies-wiremock"><code>702-technologies-wiremock</code></a></td><td>3</td><td>0</td><td>3</td></tr>
+<tr><td colspan="4"><em>tail (total ≤ 2): <a href="https://www.skills.sh/jabrena/plinth/052-design-hamburger-method"><code>052-design-hamburger-method</code></a> (1/0), <a href="https://www.skills.sh/jabrena/plinth/112-java-maven-plugins"><code>112-java-maven-plugins</code></a> (0/1)</em></td></tr>
+</tbody>
+</table>
+<p>Same pattern, sharper. <code>707-…-hexagonal-architecture</code> is near-universal in both (32/32, 36/38) — contractual. The Quarkus scaffold and the persistence skills are used by both cohorts, but the gap is wider than on Problem 1: <code>413-…-flyway</code> 32/32 → 21/38, <code>423-…-acceptance-tests</code> 31 → 23, <code>421-…-unit-tests</code> 31 → 10. The pure-knowledge skills collapse outright: <code>704-technologies-sql</code> 26 → 1, <code>124-java-secure-coding</code> 19 → 0, <code>126-java-exception-handling</code> 20 → 1, <code>054-design-tdd</code> 13 → 0, <code>122-java-type-design</code> 11 → 0, and the <code>121</code>/<code>130</code>/<code>123</code> design skills 5–8 → 0. As on Problem 1, <code>111-java-maven-dependencies</code> is the lone skill S5 leans on harder (4 → 13). Self-directed agent use is rarer here too — 32 of 38 S5 runs used no agent at all, against 19 of 30 on Problem 1 — so on the harder problem the tools fall back to plain implementation even more.</p>
+<p><strong>Across both problems the split is the same.</strong> Skills that name a <em>technology the plan already specifies</em> — framework create / rest / test, hexagonal architecture, Flyway, JDBC, WireMock — get used with or without the command. Skills that encode <em>cross-cutting practice</em> — <code>openspec</code> planning, <code>openapi</code>, secure-coding, exception-handling, type-design, TDD, OO / design-pattern, observability — are pulled in almost only when <code>/implement-spec</code> drives. That difference is what the &quot;14.2 vs 6.0&quot; is made of.</p>
 <p><strong>Hypothesis 2 is supported.</strong> Autonomous skill and agent use tracks the delegation command, not the richness of the specification the agent is handed.</p>
 <h2>Hypothesis 3 revisited: does the architecture survive without the command?</h2>
 <p>Part 1's finding was that the hexagonal scaffold in <code>scenario4</code> came from the written <code>design.md</code>, not from any tool's taste. If that is true, S5 should produce the same structure from the same plan — even with no orchestration.</p>
@@ -327,7 +413,6 @@ The hexagonal scaffold and the ArchUnit boundary test appear in 67 of 68 direct 
 <p>The data points at a handful of concrete changes to <code>/implement-spec</code>, each tied to a finding above:</p>
 <ol>
 <li><strong>Cut the latency — scale orchestration to the task.</strong> The full tech-lead + framework-coder fan-out runs on every task, but the rework payoff only lands on the integration-heavy problem; on Problem 1 it buys nothing and still costs ~36% more wall time and more than twice the wall-time-outlier rate. Grade the task up front — integration count, persistence, migrations, concurrency, external services — and run the full fan-out only above a threshold. Below it, a single implementation pass plus one verification checkpoint should match it for far less time.</li>
-<li><strong>Find and keep only the active ingredient.</strong> An S4 run pulls ~14 skills and 2 agents; the correction-rate benefit may come from a single verification pass. Log which sub-step fired and what each one caught, then drop — or background — the steps that never move rework.</li>
 </ol>
 <h2>Share your insights</h2>
 <p>Share findings or raise questions about the harness itself on <a href="https://github.com/jabrena/plinth/discussions">GitHub Discussions</a>.</p>

--- a/docs/blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.html
+++ b/docs/blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.html
@@ -108,7 +108,7 @@
 <div class="row">
 <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
 <article role="main" class="blog-post">
-<p>This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. In <a href="https://jabrena.github.io/plinth/blog/2026/07/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-1.html">Part 1</a> article, it showed the <a href="https://github.com/jabrena/plinth/tree/main/benchmarks">benchmark</a> results around 4 scenarios:</p>
+<p>This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. The <a href="https://jabrena.github.io/plinth/blog/2026/07/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-1.html">Part 1</a> article showed the <a href="https://github.com/jabrena/plinth/tree/main/benchmarks">benchmark</a> results across 4 scenarios:</p>
 <table>
 <thead>
 <tr><th>Scenario</th><th>What the agent gets</th></tr>
@@ -120,7 +120,7 @@
 <tr><td><code>scenario4</code></td><td>An OpenSpec change created by the Plinth skill <code>/create-spec</code> and enriched with <code>/explore-design</code> and finally implemented via <code>/implement-spec</code>.</td></tr>
 </tbody>
 </table>
-<p>The benchmark tried to validate the followed Hyphoteses:</p>
+<p>The benchmark tried to validate the following hypotheses:</p>
 <ul>
 <li><strong>Hypothesis 1:</strong> Richer workflows reduce implementation rework.</li>
 <li><strong>Hypothesis 2:</strong> Delegation workflows encourage autonomous use of reusable skills.</li>
@@ -150,14 +150,14 @@
 <tr><th>Problem</th><th>What it is</th></tr>
 </thead>
 <tbody>
-<tr><td><a href="https://github.com/jabrena/plinth/tree/main/benchmarks/problem1">Problem 1</a> — God Analysis API</td><td>The original benchmark problem (<a href="https://github.com/jabrena/latency-problems/blob/master/docs/problem1/README.md">latency-problems Problem 1</a>): a REST API that fans out to a third-party service and aggregates the results. A pure <strong>fan-out-and-sum</strong> problem, carried over from Part 1.</td></tr>
-<tr><td><a href="https://github.com/jabrena/plinth/tree/main/benchmarks/problem2">Problem 2</a> — Greek Gods API</td><td>New in Part 2 (<a href="https://github.com/jabrena/latency-problems/blob/master/docs/problem5/README.md">latency-problems Problem 5</a>): a REST API that periodically syncs a Greek-gods catalogue from a third-party service into a relational database via Flyway. A <strong>persistence-and-scheduling</strong> problem, not a pure fan-out-and-sum one.</td></tr>
+<tr><td><a href="https://github.com/jabrena/plinth/tree/main/benchmarks/problem1">Problem 1</a> — God Analysis API</td><td>The original benchmark problem (<a href="https://github.com/jabrena/latency-problems/blob/master/docs/problem1/README.md">latency-problems Problem 1</a>): a <strong>Spring Boot</strong> REST API that fans out to a third-party service and aggregates the results. A pure <strong>fan-out-and-sum</strong> problem, carried over from Part 1.</td></tr>
+<tr><td><a href="https://github.com/jabrena/plinth/tree/main/benchmarks/problem2">Problem 2</a> — Greek Gods API</td><td>New in Part 2 (<a href="https://github.com/jabrena/latency-problems/blob/master/docs/problem5/README.md">latency-problems Problem 5</a>): a <strong>Quarkus</strong> REST API that periodically syncs a Greek-gods catalogue from a third-party service into a relational database via Flyway. A <strong>persistence-and-scheduling</strong> problem, not a pure fan-out-and-sum one.</td></tr>
 </tbody>
 </table>
 <p>So <code>scenario4</code> (<strong>S4</strong>, orchestrated) versus <code>scenario5</code> (<strong>S5</strong>, direct) is a clean A/B: identical plan, and the only difference is whether <code>/implement-spec</code> and its agents run. Running that A/B across both problems shows whether the answer is problem-dependent.</p>
-<p>The dataset has also grown a lot — from the 54 runs in Part 1 to <strong>217 non-template result records</strong> across both problems, five scenarios, and tools including <code>cursor</code>, <code>codex</code>, <code>claude-code</code>, and <code>github-copilot</code> on a spread of models (Grok 4.5, GPT-5.x, Claude Sonnet 5 / Opus 5 / Fable 5, Composer).</p>
+<p>Part 2 runs the benchmark on <strong>Plinth v0.18.0</strong>; Part 1 used <strong>Plinth v0.17.0</strong>.</p>
 <h3>How long the two problems actually take</h3>
-<p>Those fences come from the full per-problem wall-clock distribution — every scenario, tool, and model pooled together. It is worth looking at that distribution on its own, because it answers the question people ask before they ask anything about workflows: <em>how long is one of these runs?</em></p>
+<p>The Tukey fences below come from the full per-problem wall-clock distribution — every scenario, tool, and model pooled together. It is worth looking at that distribution on its own, because it answers the question people ask before they ask anything about workflows: <em>how long is one of these runs?</em></p>
 <table>
 <thead>
 <tr><th>Problem</th><th>Positive timings</th><th>Q1</th><th>Median</th><th>Q3</th><th>IQR</th><th>Tukey upper fence</th><th>High outliers</th><th>Non-outlier range</th></tr>
@@ -380,8 +380,102 @@ test/.../architecture/HexagonalArchitectureTest.java
 </table>
 <p>On <strong>Problem 1</strong> the two workflows land within half a test class of each other. On <strong>Problem 2</strong> the orchestrated runs carry about <strong>one extra test class apiece</strong> (median 5.5 vs 4, mean 5.1 vs 3.8) — the same problem where S4 also cut rework in half and hit a perfect pass rate. Counting the boundary test back in keeps the shape: 6.5 vs 5 median on Problem 2, 7 vs 6 on Problem 1. So orchestration's structural fingerprint is not in the <em>architecture</em> — that is contractual — but in a slightly thicker test layer on the harder problem.</p>
 <p>The usual caveat applies: this is <strong>file presence</strong>. A <code>*Test.java</code> in the tree is not proof it compiles, runs, or asserts anything — the single acceptance flag is still the only execution signal in the dataset.</p>
+<p><strong>Which testing skills each harness reaches for.</strong> The per-problem skill tables earlier in this section pool all three tools. Splitting the <strong>same trimmed S4/S5 cohorts</strong> by harness — and keeping only the skills whose name marks them as test work (<code>*-testing-*</code>, <code>054-design-tdd</code>, <code>702-technologies-wiremock</code>) — shows each tool has its own testing-skill reflex once <code>/implement-spec</code> is out of the picture. The <code>claude-code</code> rows are restricted to <strong>Sonnet 5</strong> samples (the Opus 5 / Fable 5 runs are 1–5 apiece, too thin to read); <code>codex</code> is all GPT-5.x and <code>cursor</code> is Grok 4.5 plus a little Composer. Every cell counts <strong>retained runs that pulled the skill in at least once</strong>, sorted by the combined S4 + S5 total.</p>
+<h4><code>claude-code</code> (Sonnet 5)</h4>
+<p><strong>Problem 1 — God Analysis API (Spring Boot).</strong> S4 <code>n = 3</code>, S5 <code>n = 8</code>.</p>
+<table>
+<thead>
+<tr><th>Testing skill</th><th>S4 runs</th><th>S5 runs</th><th>Total</th></tr>
+</thead>
+<tbody>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/323-frameworks-spring-boot-testing-acceptance-tests"><code>323-frameworks-spring-boot-testing-acceptance-tests</code></a></td><td>3</td><td>4</td><td>7</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/702-technologies-wiremock"><code>702-technologies-wiremock</code></a></td><td>3</td><td>4</td><td>7</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/321-frameworks-spring-boot-testing-unit-tests"><code>321-frameworks-spring-boot-testing-unit-tests</code></a></td><td>3</td><td>3</td><td>6</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/322-frameworks-spring-boot-testing-integration-tests"><code>322-frameworks-spring-boot-testing-integration-tests</code></a></td><td>3</td><td>3</td><td>6</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/130-java-testing-strategies"><code>130-java-testing-strategies</code></a></td><td>1</td><td>0</td><td>1</td></tr>
+</tbody>
+</table>
+<p><strong>Problem 2 — Greek Gods API (Quarkus).</strong> S4 <code>n = 10</code>, S5 <code>n = 10</code>.</p>
+<table>
+<thead>
+<tr><th>Testing skill</th><th>S4 runs</th><th>S5 runs</th><th>Total</th></tr>
+</thead>
+<tbody>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/423-frameworks-quarkus-testing-acceptance-tests"><code>423-frameworks-quarkus-testing-acceptance-tests</code></a></td><td>10</td><td>2</td><td>12</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/421-frameworks-quarkus-testing-unit-tests"><code>421-frameworks-quarkus-testing-unit-tests</code></a></td><td>10</td><td>0</td><td>10</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/130-java-testing-strategies"><code>130-java-testing-strategies</code></a></td><td>2</td><td>0</td><td>2</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/054-design-tdd"><code>054-design-tdd</code></a></td><td>1</td><td>0</td><td>1</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/422-frameworks-quarkus-testing-integration-tests"><code>422-frameworks-quarkus-testing-integration-tests</code></a></td><td>1</td><td>0</td><td>1</td></tr>
+</tbody>
+</table>
+<p>Under orchestration Sonnet 5 logs the framework testing trio (unit / integration / acceptance) in every run; strip the command and almost all of it disappears. On Problem 2 the only testing skill any direct Sonnet 5 run records is <code>423-…-acceptance-tests</code>, in 2 of 10 — the sparse self-directed profile seen everywhere else for this tool.</p>
+<h4><code>codex</code> (GPT-5.x)</h4>
+<p><strong>Problem 1 — God Analysis API (Spring Boot).</strong> S4 <code>n = 3</code>, S5 <code>n = 9</code>.</p>
+<table>
+<thead>
+<tr><th>Testing skill</th><th>S4 runs</th><th>S5 runs</th><th>Total</th></tr>
+</thead>
+<tbody>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/322-frameworks-spring-boot-testing-integration-tests"><code>322-frameworks-spring-boot-testing-integration-tests</code></a></td><td>3</td><td>5</td><td>8</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/323-frameworks-spring-boot-testing-acceptance-tests"><code>323-frameworks-spring-boot-testing-acceptance-tests</code></a></td><td>3</td><td>5</td><td>8</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/133-java-testing-acceptance-tests"><code>133-java-testing-acceptance-tests</code></a></td><td>0</td><td>5</td><td>5</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/321-frameworks-spring-boot-testing-unit-tests"><code>321-frameworks-spring-boot-testing-unit-tests</code></a></td><td>3</td><td>1</td><td>4</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/702-technologies-wiremock"><code>702-technologies-wiremock</code></a></td><td>3</td><td>0</td><td>3</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/130-java-testing-strategies"><code>130-java-testing-strategies</code></a></td><td>2</td><td>0</td><td>2</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/054-design-tdd"><code>054-design-tdd</code></a></td><td>0</td><td>1</td><td>1</td></tr>
+</tbody>
+</table>
+<p><strong>Problem 2 — Greek Gods API (Quarkus).</strong> S4 <code>n = 10</code>, S5 <code>n = 14</code>.</p>
+<table>
+<thead>
+<tr><th>Testing skill</th><th>S4 runs</th><th>S5 runs</th><th>Total</th></tr>
+</thead>
+<tbody>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/423-frameworks-quarkus-testing-acceptance-tests"><code>423-frameworks-quarkus-testing-acceptance-tests</code></a></td><td>9</td><td>11</td><td>20</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/422-frameworks-quarkus-testing-integration-tests"><code>422-frameworks-quarkus-testing-integration-tests</code></a></td><td>9</td><td>6</td><td>15</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/421-frameworks-quarkus-testing-unit-tests"><code>421-frameworks-quarkus-testing-unit-tests</code></a></td><td>9</td><td>5</td><td>14</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/133-java-testing-acceptance-tests"><code>133-java-testing-acceptance-tests</code></a></td><td>3</td><td>10</td><td>13</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/130-java-testing-strategies"><code>130-java-testing-strategies</code></a></td><td>4</td><td>0</td><td>4</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/054-design-tdd"><code>054-design-tdd</code></a></td><td>3</td><td>0</td><td>3</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/702-technologies-wiremock"><code>702-technologies-wiremock</code></a></td><td>2</td><td>0</td><td>2</td></tr>
+</tbody>
+</table>
+<p><code>codex</code> keeps reaching for testing skills without the command — but it drifts from the framework-specific <code>323</code>/<code>423</code> toward the generic <code>133-java-testing-acceptance-tests</code> (0 → 5 on Problem 1, 3 → 10 on Problem 2). Unit- and integration-testing skills survive into S5 at a reduced rate, while the practice skills (<code>130</code>, <code>054-design-tdd</code>, <code>702-technologies-wiremock</code>) fall to zero.</p>
+<h4><code>cursor</code> (Grok 4.5 / Composer)</h4>
+<p><strong>Problem 1 — God Analysis API (Spring Boot).</strong> S4 <code>n = 9</code>, S5 <code>n = 11</code>.</p>
+<table>
+<thead>
+<tr><th>Testing skill</th><th>S4 runs</th><th>S5 runs</th><th>Total</th></tr>
+</thead>
+<tbody>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/702-technologies-wiremock"><code>702-technologies-wiremock</code></a></td><td>8</td><td>10</td><td>18</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/323-frameworks-spring-boot-testing-acceptance-tests"><code>323-frameworks-spring-boot-testing-acceptance-tests</code></a></td><td>8</td><td>9</td><td>17</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/322-frameworks-spring-boot-testing-integration-tests"><code>322-frameworks-spring-boot-testing-integration-tests</code></a></td><td>7</td><td>9</td><td>16</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/321-frameworks-spring-boot-testing-unit-tests"><code>321-frameworks-spring-boot-testing-unit-tests</code></a></td><td>7</td><td>8</td><td>15</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/054-design-tdd"><code>054-design-tdd</code></a></td><td>4</td><td>1</td><td>5</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/130-java-testing-strategies"><code>130-java-testing-strategies</code></a></td><td>1</td><td>1</td><td>2</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/131-java-testing-unit-testing"><code>131-java-testing-unit-testing</code></a></td><td>0</td><td>1</td><td>1</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/132-java-testing-integration-testing"><code>132-java-testing-integration-testing</code></a></td><td>0</td><td>1</td><td>1</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/133-java-testing-acceptance-tests"><code>133-java-testing-acceptance-tests</code></a></td><td>0</td><td>1</td><td>1</td></tr>
+</tbody>
+</table>
+<p><strong>Problem 2 — Greek Gods API (Quarkus).</strong> S4 <code>n = 11</code>, S5 <code>n = 11</code>.</p>
+<table>
+<thead>
+<tr><th>Testing skill</th><th>S4 runs</th><th>S5 runs</th><th>Total</th></tr>
+</thead>
+<tbody>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/423-frameworks-quarkus-testing-acceptance-tests"><code>423-frameworks-quarkus-testing-acceptance-tests</code></a></td><td>11</td><td>9</td><td>20</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/421-frameworks-quarkus-testing-unit-tests"><code>421-frameworks-quarkus-testing-unit-tests</code></a></td><td>11</td><td>5</td><td>16</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/422-frameworks-quarkus-testing-integration-tests"><code>422-frameworks-quarkus-testing-integration-tests</code></a></td><td>8</td><td>1</td><td>9</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/054-design-tdd"><code>054-design-tdd</code></a></td><td>8</td><td>0</td><td>8</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/130-java-testing-strategies"><code>130-java-testing-strategies</code></a></td><td>2</td><td>0</td><td>2</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/702-technologies-wiremock"><code>702-technologies-wiremock</code></a></td><td>1</td><td>0</td><td>1</td></tr>
+</tbody>
+</table>
+<p><code>cursor</code> is the steadiest of the three. On Problem 1 the Spring testing trio plus <code>702-technologies-wiremock</code> appear at near-identical rates with and without the command. On Problem 2 direct runs still hold onto acceptance and unit testing, but <code>054-design-tdd</code> (8 → 0) and integration testing (8 → 1) are the ones that only survive under orchestration.</p>
 <h3>Where orchestration does leave a fingerprint: the Maven build</h3>
-<p>Architecture is contractual, but the <code>pom.xml</code> is not fully specified, and that is where the two workflows differ — a little. Decoding and parsing every retained Problem 2 POM (all 70 are strict-Base64, well-formed XML, Java 25, and import the Quarkus BOM):</p>
+<p>Architecture is contractual, but the <code>pom.xml</code> is not fully specified, and that is where the two workflows differ — a little. Decoding and parsing every retained Problem 2 POM (all 70 are strict-Base64, well-formed XML, Java 25, and import the Quarkus BOM) gives:</p>
 <table>
 <thead>
 <tr><th>POM property</th><th>S4 (32 POMs)</th><th>S5 (38 POMs)</th></tr>
@@ -392,12 +486,13 @@ test/.../architecture/HexagonalArchitectureTest.java
 <tr><td><code>quarkus</code> application packaging (rest are <code>jar</code>)</td><td>18/32</td><td>21/38</td></tr>
 <tr><td>SmallRye OpenAPI dependency</td><td>31/32</td><td>30/38</td></tr>
 <tr><td>ArchUnit dependency</td><td>32/32</td><td>37/38</td></tr>
-<tr><td>Native-build profile</td><td>15/32</td><td>18/38</td></tr>
 <tr><td>Custom repositories / multi-module</td><td>0/32</td><td>0/38</td></tr>
-<tr><td>Production / test / error-named Java files (means)</td><td>16.3 / 6.5 / 3.7</td><td>15.5 / 5.7 / 3.2</td></tr>
+<tr><td>Production Java files (mean per run)</td><td>16.3</td><td>15.5</td></tr>
+<tr><td>Test Java files (mean per run)</td><td>6.5</td><td>5.7</td></tr>
+<tr><td>Error-handling classes — name contains <code>Error</code>/<code>Exception</code> (mean per run)</td><td>3.7</td><td>3.2</td></tr>
 </tbody>
 </table>
-<p>S4 pins the full Compiler / Surefire / Failsafe / Quarkus plugin set a bit more often (28/32 vs 26/38) and writes marginally more production and test files — a <strong>5–15% edge</strong>, not the large &quot;assurance surface&quot; gap an earlier read of the data suggested, and file presence still says nothing about whether those tests execute. On everything else the two are within a rounding error of each other. Packaging is a coin flip in <em>both</em> workflows: only about half of each cohort ships a <code>quarkus</code> application POM, the rest fall back to plain <code>jar</code>.</p>
+<p>S4 pins the full Compiler / Surefire / Failsafe / Quarkus plugin set a bit more often (28/32 vs 26/38) and writes marginally more production and test files — a <strong>5–15% edge</strong>, not the large &quot;assurance surface&quot; gap an earlier read of the data suggested, and file presence still says nothing about whether those tests execute. On everything else the two are within a rounding error of each other. Packaging is a coin flip in <em>both</em> workflows: only about half of each cohort ships a <code>quarkus</code> application POM; the rest fall back to plain <code>jar</code>.</p>
 <p>The bigger story in the POMs is drift that neither workflow controls. Retained Quarkus platform versions span <strong>3.27.0 to 3.39.1</strong>, and same-commit S4/S5 pairs sometimes pick different platform versions. A recurring set of POMs declares both <code>quarkus-rest</code> and <code>quarkus-rest-jackson</code>, or adds <code>quarkus-agroal</code> next to a JDBC driver that already pulls it in; several mix <code>quarkus-junit</code> with the older <code>quarkus-junit5-*</code> coordinate family. None of that is caused by the workflow — it is the agents choosing dependencies run to run — but it is exactly the kind of variance a benchmark has to normalize before it can compare anything downstream.</p>
 <p><strong>Hypothesis 3 is supported, with a sharper conclusion than Part 1.</strong> Project shape — framework, layering, boundary test — is not an orchestration effect at all; it is a written-decision effect, reproduced just as reliably by direct implementation because the OpenSpec input prescribes it. Whatever value <code>/implement-spec</code> adds shows up in execution discipline and correction cycles, not in project structure.</p>
 <h2>Takeaways</h2>
@@ -412,7 +507,7 @@ The hexagonal scaffold and the ArchUnit boundary test appear in 67 of 68 direct 
 <h2>Next steps</h2>
 <p>The data points at a handful of concrete changes to <code>/implement-spec</code>, each tied to a finding above:</p>
 <ol>
-<li><strong>Cut the latency — scale orchestration to the task.</strong> The full tech-lead + framework-coder fan-out runs on every task, but the rework payoff only lands on the integration-heavy problem; on Problem 1 it buys nothing and still costs ~36% more wall time and more than twice the wall-time-outlier rate. Grade the task up front — integration count, persistence, migrations, concurrency, external services — and run the full fan-out only above a threshold. Below it, a single implementation pass plus one verification checkpoint should match it for far less time.</li>
+<li><strong>Cut the latency.</strong> Running the full agent fan-out on every job makes S4 about 36% slower than plain implementation (roughly 16 vs 10 minutes), and that extra time only earns its keep on hard, integration-heavy work. For simple problems, skip the fan-out and do one implementation pass plus one review — same result, much faster.</li>
 </ol>
 <h2>Share your insights</h2>
 <p>Share findings or raise questions about the harness itself on <a href="https://github.com/jabrena/plinth/discussions">GitHub Discussions</a>.</p>

--- a/docs/feed.xml
+++ b/docs/feed.xml
@@ -2,7 +2,7 @@
 <feed xmlns='http://www.w3.org/2005/Atom' xml:lang='en'>
   <id>https://jabrena.github.io/plinth/</id>
   <title>Plinth</title>
-  <updated>2026-09-02T19:27:17+0200</updated>
+  <updated>2026-09-03T10:52:47+0200</updated>
   <link rel="alternate" type="text/html" href="https://jabrena.github.io/plinth/" />
   <link rel='self' type='application/atom+xml' href='https://jabrena.github.io/plinth//feed.xml' />
   <entry>
@@ -11,7 +11,15 @@
     <link></link>
     <link rel="alternate" type="text/html" href="https://jabrena.github.io/plinth//blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.html" />
     <updated>2026-09-05T00:00:00+0200</updated>
-    <summary>This is the second article in a series that tries to put a number on the value of Plinth&apos;s AI-native development workflow for Java. Part 1 built a benchmark that hands the same problem to several agent tools under briefs of increasing structure, logs every run as a validated JSON record, and uses those records to test three hypotheses about whether richer workflows actually pay off. The benchmark t...</summary>
+    <summary>This is the second article in a series that tries to put a number on the value of Plinth&apos;s AI-native development workflow for Java. In Part 1 article, it showed the benchmark results around 4 scenarios:
+
+
+ScenarioWhat the agent gets
+
+
+scenario1A minimal README only — baseline, sparsest possible brief
+scenario2A full functional-requirements package: user story, Gherkin, OpenAPI, ADRs
+scenario3An Ope...</summary>
   </entry>
   <entry>
     <id>https://jabrena.github.io/plinth//blog/2026/08/release-0.18.0.html</id>

--- a/docs/feed.xml
+++ b/docs/feed.xml
@@ -2,7 +2,7 @@
 <feed xmlns='http://www.w3.org/2005/Atom' xml:lang='en'>
   <id>https://jabrena.github.io/plinth/</id>
   <title>Plinth</title>
-  <updated>2026-09-03T10:52:47+0200</updated>
+  <updated>2026-09-03T16:40:38+0200</updated>
   <link rel="alternate" type="text/html" href="https://jabrena.github.io/plinth/" />
   <link rel='self' type='application/atom+xml' href='https://jabrena.github.io/plinth//feed.xml' />
   <entry>
@@ -11,7 +11,7 @@
     <link></link>
     <link rel="alternate" type="text/html" href="https://jabrena.github.io/plinth//blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.html" />
     <updated>2026-09-05T00:00:00+0200</updated>
-    <summary>This is the second article in a series that tries to put a number on the value of Plinth&apos;s AI-native development workflow for Java. In Part 1 article, it showed the benchmark results around 4 scenarios:
+    <summary>This is the second article in a series that tries to put a number on the value of Plinth&apos;s AI-native development workflow for Java. The Part 1 article showed the benchmark results across 4 scenarios:
 
 
 ScenarioWhat the agent gets
@@ -19,7 +19,7 @@ ScenarioWhat the agent gets
 
 scenario1A minimal README only — baseline, sparsest possible brief
 scenario2A full functional-requirements package: user story, Gherkin, OpenAPI, ADRs
-scenario3An Ope...</summary>
+scenario3An OpenSp...</summary>
   </entry>
   <entry>
     <id>https://jabrena.github.io/plinth//blog/2026/08/release-0.18.0.html</id>

--- a/docs/feed.xml
+++ b/docs/feed.xml
@@ -2,9 +2,17 @@
 <feed xmlns='http://www.w3.org/2005/Atom' xml:lang='en'>
   <id>https://jabrena.github.io/plinth/</id>
   <title>Plinth</title>
-  <updated>2026-08-27T17:51:38+0200</updated>
+  <updated>2026-09-02T19:27:17+0200</updated>
   <link rel="alternate" type="text/html" href="https://jabrena.github.io/plinth/" />
   <link rel='self' type='application/atom+xml' href='https://jabrena.github.io/plinth//feed.xml' />
+  <entry>
+    <id>https://jabrena.github.io/plinth//blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.html</id>
+    <title>Validating hypotheses about Plinth workflow with a Benchmark Part 2</title>
+    <link></link>
+    <link rel="alternate" type="text/html" href="https://jabrena.github.io/plinth//blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.html" />
+    <updated>2026-09-05T00:00:00+0200</updated>
+    <summary>This is the second article in a series that tries to put a number on the value of Plinth&apos;s AI-native development workflow for Java. Part 1 built a benchmark that hands the same problem to several agent tools under briefs of increasing structure, logs every run as a validated JSON record, and uses those records to test three hypotheses about whether richer workflows actually pay off. The benchmark t...</summary>
+  </entry>
   <entry>
     <id>https://jabrena.github.io/plinth//blog/2026/08/release-0.18.0.html</id>
     <title>What&apos;s new in Plinth 0.18.0?</title>

--- a/docs/index.html
+++ b/docs/index.html
@@ -116,6 +116,35 @@
 <div class="posts-section">
 <h2 class="section-title"><i class="fa fa-rss"></i> Latest Posts</h2>
 <article class="post-preview">
+<h3 class="post-title"><a href="blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.html">Validating hypotheses about Plinth workflow with a Benchmark Part 2</a></h3>
+
+<p class="post-meta">
+  <i class="fa fa-calendar-o"></i>
+  2026-09-05
+    &nbsp;
+    <i class="fa fa-pencil"></i>
+    MyRobot
+  <span class="blog-tags">
+    &nbsp;
+    <i class="fa fa-tags"></i>
+      <a href="tags/blog.html">blog</a>
+      <a href="tags/agents.html">agents</a>
+      <a href="tags/skills.html">skills</a>
+      <a href="tags/openspec.html">openspec</a>
+      <a href="tags/performance.html">performance</a>
+      <a href="tags/java.html">java</a>
+  </span>
+</p>
+
+<div class="post-entry-container">
+  <div class="post-entry">
+    This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. Part 1 built a benchmark that hands the same problem to several agent tools under briefs of increasing structure, logs every run as a validated JSON record, and uses those records to test three hypotheses about whether richer workflows actually pay off. The benchmark t...
+    <p></p>
+    <a href="blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.html" class="post-read-more">[Read More]</a>
+  </div>
+</div>
+</article>
+<article class="post-preview">
 <h3 class="post-title"><a href="blog/2026/08/release-0.18.0.html">What&apos;s new in Plinth 0.18.0?</a></h3>
 
 <p class="post-meta">
@@ -236,38 +265,6 @@ This release brings several improvements to the development workflow, but the mo
 Thanks to our community members in Urumqi, Singapore, Des Moines, Bengaluru, a...
     <p></p>
     <a href="blog/2026/07/release-0.17.0.html" class="post-read-more">[Read More]</a>
-  </div>
-</div>
-</article>
-<article class="post-preview">
-<h3 class="post-title"><a href="blog/2026/07/why-do-i-need-to-use-the-parallel-change-pattern.html">Why Do I Need to Use the Parallel Change Pattern?</a></h3>
-
-<p class="post-meta">
-  <i class="fa fa-calendar-o"></i>
-  2026-07-04
-    &nbsp;
-    <i class="fa fa-pencil"></i>
-    MyRobot
-  <span class="blog-tags">
-    &nbsp;
-    <i class="fa fa-tags"></i>
-      <a href="tags/blog.html">blog</a>
-      <a href="tags/skills.html">skills</a>
-      <a href="tags/agents.html">agents</a>
-      <a href="tags/design.html">design</a>
-      <a href="tags/software-engineering.html">software-engineering</a>
-      <a href="tags/java.html">java</a>
-  </span>
-</p>
-
-<div class="post-entry-container">
-  <div class="post-entry">
-    The hidden risk in fast code generation
-AI coding tools are very good at producing a complete-looking change from a short request.
-That is useful when the change is local. It becomes risky when the change crosses compatibility boundaries: database schemas, public APIs, event contracts, configuration keys, command outputs, generated artifacts, or workflows consumed by other services.
-A human enginee...
-    <p></p>
-    <a href="blog/2026/07/why-do-i-need-to-use-the-parallel-change-pattern.html" class="post-read-more">[Read More]</a>
   </div>
 </div>
 </article>

--- a/docs/index.html
+++ b/docs/index.html
@@ -138,7 +138,15 @@
 
 <div class="post-entry-container">
   <div class="post-entry">
-    This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. Part 1 built a benchmark that hands the same problem to several agent tools under briefs of increasing structure, logs every run as a validated JSON record, and uses those records to test three hypotheses about whether richer workflows actually pay off. The benchmark t...
+    This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. In Part 1 article, it showed the benchmark results around 4 scenarios:
+
+
+ScenarioWhat the agent gets
+
+
+scenario1A minimal README only — baseline, sparsest possible brief
+scenario2A full functional-requirements package: user story, Gherkin, OpenAPI, ADRs
+scenario3An Ope...
     <p></p>
     <a href="blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.html" class="post-read-more">[Read More]</a>
   </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -138,7 +138,7 @@
 
 <div class="post-entry-container">
   <div class="post-entry">
-    This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. In Part 1 article, it showed the benchmark results around 4 scenarios:
+    This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. The Part 1 article showed the benchmark results across 4 scenarios:
 
 
 ScenarioWhat the agent gets
@@ -146,7 +146,7 @@ ScenarioWhat the agent gets
 
 scenario1A minimal README only — baseline, sparsest possible brief
 scenario2A full functional-requirements package: user story, Gherkin, OpenAPI, ADRs
-scenario3An Ope...
+scenario3An OpenSp...
     <p></p>
     <a href="blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.html" class="post-read-more">[Read More]</a>
   </div>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -5,6 +5,10 @@
         <lastmod>2015-02-01</lastmod>
     </url>
     <url>
+        <loc>https://jabrena.github.io/plinth/blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.html</loc>
+        <lastmod>2026-09-05</lastmod>
+    </url>
+    <url>
         <loc>https://jabrena.github.io/plinth/blog/2026/08/release-0.18.0.html</loc>
         <lastmod>2026-08-03</lastmod>
     </url>
@@ -89,14 +93,6 @@
         <lastmod>2025-07-12</lastmod>
     </url>
     <url>
-        <loc>https://jabrena.github.io/plinth/courses/system-prompts-java/module-5-performance.html</loc>
-        <lastmod>2025-09-17</lastmod>
-    </url>
-    <url>
-        <loc>https://jabrena.github.io/plinth/courses/profile-memory-leak/module-3-analysis.html</loc>
-        <lastmod>2025-09-17</lastmod>
-    </url>
-    <url>
         <loc>https://jabrena.github.io/plinth/courses/system-prompts-java/module-4-modern-java.html</loc>
         <lastmod>2025-09-17</lastmod>
     </url>
@@ -145,11 +141,15 @@
         <lastmod>2025-09-17</lastmod>
     </url>
     <url>
-        <loc>https://jabrena.github.io/plinth/courses/java-generics/index.html</loc>
-        <lastmod>2025-09-13</lastmod>
+        <loc>https://jabrena.github.io/plinth/courses/system-prompts-java/module-5-performance.html</loc>
+        <lastmod>2025-09-17</lastmod>
     </url>
     <url>
-        <loc>https://jabrena.github.io/plinth/courses/java-generics/module-1-foundations.html</loc>
+        <loc>https://jabrena.github.io/plinth/courses/profile-memory-leak/module-3-analysis.html</loc>
+        <lastmod>2025-09-17</lastmod>
+    </url>
+    <url>
+        <loc>https://jabrena.github.io/plinth/courses/java-generics/index.html</loc>
         <lastmod>2025-09-13</lastmod>
     </url>
     <url>
@@ -166,6 +166,10 @@
     </url>
     <url>
         <loc>https://jabrena.github.io/plinth/courses/java-generics/module-2-wildcards.html</loc>
+        <lastmod>2025-09-13</lastmod>
+    </url>
+    <url>
+        <loc>https://jabrena.github.io/plinth/courses/java-generics/module-1-foundations.html</loc>
         <lastmod>2025-09-13</lastmod>
     </url>
 </urlset>

--- a/docs/tags/agents.html
+++ b/docs/tags/agents.html
@@ -86,6 +86,35 @@
 
 <div class="posts-list">
 <article class="post-preview">
+<h2 class="post-title"><a href="../blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.html">Validating hypotheses about Plinth workflow with a Benchmark Part 2</a></h2>
+
+<p class="post-meta">
+  <i class="fa fa-calendar-o"></i>
+  2026-09-05
+    &nbsp;
+    <i class="fa fa-pencil"></i>
+    MyRobot
+  <span class="blog-tags">
+    &nbsp;
+    <i class="fa fa-tags"></i>
+      <a href="../tags/blog.html">blog</a>
+      <a href="../tags/agents.html">agents</a>
+      <a href="../tags/skills.html">skills</a>
+      <a href="../tags/openspec.html">openspec</a>
+      <a href="../tags/performance.html">performance</a>
+      <a href="../tags/java.html">java</a>
+  </span>
+</p>
+
+<div class="post-entry-container">
+  <div class="post-entry">
+    This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. Part 1 built a benchmark that hands the same problem to several agent tools under briefs of increasing structure, logs every run as a validated JSON record, and uses those records to test three hypotheses about whether richer workflows actually pay off. The benchmark t...
+    <p></p>
+    <a href="../blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.html" class="post-read-more">[Read More]</a>
+  </div>
+</div>
+</article>
+<article class="post-preview">
 <h2 class="post-title"><a href="../blog/2026/08/release-0.18.0.html">What&apos;s new in Plinth 0.18.0?</a></h2>
 
 <p class="post-meta">

--- a/docs/tags/agents.html
+++ b/docs/tags/agents.html
@@ -108,7 +108,7 @@
 
 <div class="post-entry-container">
   <div class="post-entry">
-    This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. In Part 1 article, it showed the benchmark results around 4 scenarios:
+    This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. The Part 1 article showed the benchmark results across 4 scenarios:
 
 
 ScenarioWhat the agent gets
@@ -116,7 +116,7 @@ ScenarioWhat the agent gets
 
 scenario1A minimal README only — baseline, sparsest possible brief
 scenario2A full functional-requirements package: user story, Gherkin, OpenAPI, ADRs
-scenario3An Ope...
+scenario3An OpenSp...
     <p></p>
     <a href="../blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.html" class="post-read-more">[Read More]</a>
   </div>

--- a/docs/tags/agents.html
+++ b/docs/tags/agents.html
@@ -108,7 +108,15 @@
 
 <div class="post-entry-container">
   <div class="post-entry">
-    This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. Part 1 built a benchmark that hands the same problem to several agent tools under briefs of increasing structure, logs every run as a validated JSON record, and uses those records to test three hypotheses about whether richer workflows actually pay off. The benchmark t...
+    This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. In Part 1 article, it showed the benchmark results around 4 scenarios:
+
+
+ScenarioWhat the agent gets
+
+
+scenario1A minimal README only — baseline, sparsest possible brief
+scenario2A full functional-requirements package: user story, Gherkin, OpenAPI, ADRs
+scenario3An Ope...
     <p></p>
     <a href="../blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.html" class="post-read-more">[Read More]</a>
   </div>

--- a/docs/tags/blog.html
+++ b/docs/tags/blog.html
@@ -86,6 +86,35 @@
 
 <div class="posts-list">
 <article class="post-preview">
+<h2 class="post-title"><a href="../blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.html">Validating hypotheses about Plinth workflow with a Benchmark Part 2</a></h2>
+
+<p class="post-meta">
+  <i class="fa fa-calendar-o"></i>
+  2026-09-05
+    &nbsp;
+    <i class="fa fa-pencil"></i>
+    MyRobot
+  <span class="blog-tags">
+    &nbsp;
+    <i class="fa fa-tags"></i>
+      <a href="../tags/blog.html">blog</a>
+      <a href="../tags/agents.html">agents</a>
+      <a href="../tags/skills.html">skills</a>
+      <a href="../tags/openspec.html">openspec</a>
+      <a href="../tags/performance.html">performance</a>
+      <a href="../tags/java.html">java</a>
+  </span>
+</p>
+
+<div class="post-entry-container">
+  <div class="post-entry">
+    This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. Part 1 built a benchmark that hands the same problem to several agent tools under briefs of increasing structure, logs every run as a validated JSON record, and uses those records to test three hypotheses about whether richer workflows actually pay off. The benchmark t...
+    <p></p>
+    <a href="../blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.html" class="post-read-more">[Read More]</a>
+  </div>
+</div>
+</article>
+<article class="post-preview">
 <h2 class="post-title"><a href="../blog/2026/08/release-0.18.0.html">What&apos;s new in Plinth 0.18.0?</a></h2>
 
 <p class="post-meta">

--- a/docs/tags/blog.html
+++ b/docs/tags/blog.html
@@ -108,7 +108,7 @@
 
 <div class="post-entry-container">
   <div class="post-entry">
-    This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. In Part 1 article, it showed the benchmark results around 4 scenarios:
+    This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. The Part 1 article showed the benchmark results across 4 scenarios:
 
 
 ScenarioWhat the agent gets
@@ -116,7 +116,7 @@ ScenarioWhat the agent gets
 
 scenario1A minimal README only — baseline, sparsest possible brief
 scenario2A full functional-requirements package: user story, Gherkin, OpenAPI, ADRs
-scenario3An Ope...
+scenario3An OpenSp...
     <p></p>
     <a href="../blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.html" class="post-read-more">[Read More]</a>
   </div>

--- a/docs/tags/blog.html
+++ b/docs/tags/blog.html
@@ -108,7 +108,15 @@
 
 <div class="post-entry-container">
   <div class="post-entry">
-    This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. Part 1 built a benchmark that hands the same problem to several agent tools under briefs of increasing structure, logs every run as a validated JSON record, and uses those records to test three hypotheses about whether richer workflows actually pay off. The benchmark t...
+    This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. In Part 1 article, it showed the benchmark results around 4 scenarios:
+
+
+ScenarioWhat the agent gets
+
+
+scenario1A minimal README only — baseline, sparsest possible brief
+scenario2A full functional-requirements package: user story, Gherkin, OpenAPI, ADRs
+scenario3An Ope...
     <p></p>
     <a href="../blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.html" class="post-read-more">[Read More]</a>
   </div>

--- a/docs/tags/generics.html
+++ b/docs/tags/generics.html
@@ -112,33 +112,6 @@ Design ...
 </div>
 </article>
 <article class="post-preview">
-<h2 class="post-title"><a href="../courses/java-generics/module-1-foundations.html">Module 1: Foundations - Core Concepts and Type Safety</a></h2>
-
-<p class="post-meta">
-  <span class="blog-tags">
-    &nbsp;
-    <i class="fa fa-tags"></i>
-      <a href="../tags/java.html">java</a>
-      <a href="../tags/generics.html">generics</a>
-  </span>
-</p>
-
-<div class="post-entry-container">
-  <div class="post-entry">
-    📖 Module Overview
-Welcome to the foundation of Java Generics! In this module, you'll discover why generics were introduced, understand the problems they solve, and learn the fundamental syntax that makes Java code safer and more expressive.
-🎯 Learning Objectives
-By the end of this module, you will:
-
-Understand the core problems that generics solve
-Eliminate raw types from your code completely
-App...
-    <p></p>
-    <a href="../courses/java-generics/module-1-foundations.html" class="post-read-more">[Read More]</a>
-  </div>
-</div>
-</article>
-<article class="post-preview">
 <h2 class="post-title"><a href="../courses/java-generics/module-5-assessment.html">Module 5: Assessment - Validate Your Mastery</a></h2>
 
 <p class="post-meta">
@@ -238,6 +211,33 @@ Understand covariance, contravariance, and invariance in Java
 Mas...
     <p></p>
     <a href="../courses/java-generics/module-2-wildcards.html" class="post-read-more">[Read More]</a>
+  </div>
+</div>
+</article>
+<article class="post-preview">
+<h2 class="post-title"><a href="../courses/java-generics/module-1-foundations.html">Module 1: Foundations - Core Concepts and Type Safety</a></h2>
+
+<p class="post-meta">
+  <span class="blog-tags">
+    &nbsp;
+    <i class="fa fa-tags"></i>
+      <a href="../tags/java.html">java</a>
+      <a href="../tags/generics.html">generics</a>
+  </span>
+</p>
+
+<div class="post-entry-container">
+  <div class="post-entry">
+    📖 Module Overview
+Welcome to the foundation of Java Generics! In this module, you'll discover why generics were introduced, understand the problems they solve, and learn the fundamental syntax that makes Java code safer and more expressive.
+🎯 Learning Objectives
+By the end of this module, you will:
+
+Understand the core problems that generics solve
+Eliminate raw types from your code completely
+App...
+    <p></p>
+    <a href="../courses/java-generics/module-1-foundations.html" class="post-read-more">[Read More]</a>
   </div>
 </div>
 </article>

--- a/docs/tags/java.html
+++ b/docs/tags/java.html
@@ -108,7 +108,7 @@
 
 <div class="post-entry-container">
   <div class="post-entry">
-    This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. In Part 1 article, it showed the benchmark results around 4 scenarios:
+    This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. The Part 1 article showed the benchmark results across 4 scenarios:
 
 
 ScenarioWhat the agent gets
@@ -116,7 +116,7 @@ ScenarioWhat the agent gets
 
 scenario1A minimal README only — baseline, sparsest possible brief
 scenario2A full functional-requirements package: user story, Gherkin, OpenAPI, ADRs
-scenario3An Ope...
+scenario3An OpenSp...
     <p></p>
     <a href="../blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.html" class="post-read-more">[Read More]</a>
   </div>

--- a/docs/tags/java.html
+++ b/docs/tags/java.html
@@ -108,7 +108,15 @@
 
 <div class="post-entry-container">
   <div class="post-entry">
-    This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. Part 1 built a benchmark that hands the same problem to several agent tools under briefs of increasing structure, logs every run as a validated JSON record, and uses those records to test three hypotheses about whether richer workflows actually pay off. The benchmark t...
+    This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. In Part 1 article, it showed the benchmark results around 4 scenarios:
+
+
+ScenarioWhat the agent gets
+
+
+scenario1A minimal README only — baseline, sparsest possible brief
+scenario2A full functional-requirements package: user story, Gherkin, OpenAPI, ADRs
+scenario3An Ope...
     <p></p>
     <a href="../blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.html" class="post-read-more">[Read More]</a>
   </div>

--- a/docs/tags/java.html
+++ b/docs/tags/java.html
@@ -86,6 +86,35 @@
 
 <div class="posts-list">
 <article class="post-preview">
+<h2 class="post-title"><a href="../blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.html">Validating hypotheses about Plinth workflow with a Benchmark Part 2</a></h2>
+
+<p class="post-meta">
+  <i class="fa fa-calendar-o"></i>
+  2026-09-05
+    &nbsp;
+    <i class="fa fa-pencil"></i>
+    MyRobot
+  <span class="blog-tags">
+    &nbsp;
+    <i class="fa fa-tags"></i>
+      <a href="../tags/blog.html">blog</a>
+      <a href="../tags/agents.html">agents</a>
+      <a href="../tags/skills.html">skills</a>
+      <a href="../tags/openspec.html">openspec</a>
+      <a href="../tags/performance.html">performance</a>
+      <a href="../tags/java.html">java</a>
+  </span>
+</p>
+
+<div class="post-entry-container">
+  <div class="post-entry">
+    This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. Part 1 built a benchmark that hands the same problem to several agent tools under briefs of increasing structure, logs every run as a validated JSON record, and uses those records to test three hypotheses about whether richer workflows actually pay off. The benchmark t...
+    <p></p>
+    <a href="../blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.html" class="post-read-more">[Read More]</a>
+  </div>
+</div>
+</article>
+<article class="post-preview">
 <h2 class="post-title"><a href="../blog/2026/08/release-0.18.0.html">What&apos;s new in Plinth 0.18.0?</a></h2>
 
 <p class="post-meta">
@@ -330,61 +359,6 @@ Symptom: memory usage drifts under real production load. Constraint: profiling c
 With JFR, production evidence replaces g...
     <p></p>
     <a href="../blog/2025/09/jfr-modern-java-profiling.html" class="post-read-more">[Read More]</a>
-  </div>
-</div>
-</article>
-<article class="post-preview">
-<h2 class="post-title"><a href="../courses/system-prompts-java/module-5-performance.html">Module 5: Performance - Optimization &amp; Profiling</a></h2>
-
-<p class="post-meta">
-  <span class="blog-tags">
-    &nbsp;
-    <i class="fa fa-tags"></i>
-      <a href="../tags/java.html">java</a>
-      <a href="../tags/system-prompts.html">system-prompts</a>
-  </span>
-</p>
-
-<div class="post-entry-container">
-  <div class="post-entry">
-    🎯 Learning Objectives
-By the end of this module, you will:
-
-Create JMeter performance tests using @151-java-performance-jmeter
-Profile applications comprehensively using @161-java-profiling-detect
-Analyze performance bottlenecks using @162-java-profiling-analyze
-Compare performance improvements using @164-java-profiling-compare
-Benchmark code with JMH for micro-optimizations
-Apply systematic perfo...
-    <p></p>
-    <a href="../courses/system-prompts-java/module-5-performance.html" class="post-read-more">[Read More]</a>
-  </div>
-</div>
-</article>
-<article class="post-preview">
-<h2 class="post-title"><a href="../courses/profile-memory-leak/module-3-analysis.html">Module 3: Analysis and Evidence Collection</a></h2>
-
-<p class="post-meta">
-  <span class="blog-tags">
-    &nbsp;
-    <i class="fa fa-tags"></i>
-      <a href="../tags/java.html">java</a>
-      <a href="../tags/profiling.html">profiling</a>
-  </span>
-</p>
-
-<div class="post-entry-container">
-  <div class="post-entry">
-    Systematic Analysis using @162-java-profiling-analyze
-⏱️ Duration: 2 hours
-🎯 Learning Objectives:
-- Master the systematic analysis framework from @162-java-profiling-analyze
-- Learn to categorize and prioritize performance issues using Impact/Effort scoring
-- Create structured documentation following professional templates
-- Develop cross-correlation analysis skills for multiple profiling results
-...
-    <p></p>
-    <a href="../courses/profile-memory-leak/module-3-analysis.html" class="post-read-more">[Read More]</a>
   </div>
 </div>
 </article>
@@ -723,6 +697,61 @@ Duration: 3 ...
 </div>
 </article>
 <article class="post-preview">
+<h2 class="post-title"><a href="../courses/system-prompts-java/module-5-performance.html">Module 5: Performance - Optimization &amp; Profiling</a></h2>
+
+<p class="post-meta">
+  <span class="blog-tags">
+    &nbsp;
+    <i class="fa fa-tags"></i>
+      <a href="../tags/java.html">java</a>
+      <a href="../tags/system-prompts.html">system-prompts</a>
+  </span>
+</p>
+
+<div class="post-entry-container">
+  <div class="post-entry">
+    🎯 Learning Objectives
+By the end of this module, you will:
+
+Create JMeter performance tests using @151-java-performance-jmeter
+Profile applications comprehensively using @161-java-profiling-detect
+Analyze performance bottlenecks using @162-java-profiling-analyze
+Compare performance improvements using @164-java-profiling-compare
+Benchmark code with JMH for micro-optimizations
+Apply systematic perfo...
+    <p></p>
+    <a href="../courses/system-prompts-java/module-5-performance.html" class="post-read-more">[Read More]</a>
+  </div>
+</div>
+</article>
+<article class="post-preview">
+<h2 class="post-title"><a href="../courses/profile-memory-leak/module-3-analysis.html">Module 3: Analysis and Evidence Collection</a></h2>
+
+<p class="post-meta">
+  <span class="blog-tags">
+    &nbsp;
+    <i class="fa fa-tags"></i>
+      <a href="../tags/java.html">java</a>
+      <a href="../tags/profiling.html">profiling</a>
+  </span>
+</p>
+
+<div class="post-entry-container">
+  <div class="post-entry">
+    Systematic Analysis using @162-java-profiling-analyze
+⏱️ Duration: 2 hours
+🎯 Learning Objectives:
+- Master the systematic analysis framework from @162-java-profiling-analyze
+- Learn to categorize and prioritize performance issues using Impact/Effort scoring
+- Create structured documentation following professional templates
+- Develop cross-correlation analysis skills for multiple profiling results
+...
+    <p></p>
+    <a href="../courses/profile-memory-leak/module-3-analysis.html" class="post-read-more">[Read More]</a>
+  </div>
+</div>
+</article>
+<article class="post-preview">
 <h2 class="post-title"><a href="../courses/java-generics/index.html">Mastering Java Generics - From Type Safety to Advanced Patterns</a></h2>
 
 <p class="post-meta">
@@ -745,33 +774,6 @@ Eliminate ClassCastException through proper generic type usage
 Design ...
     <p></p>
     <a href="../courses/java-generics/index.html" class="post-read-more">[Read More]</a>
-  </div>
-</div>
-</article>
-<article class="post-preview">
-<h2 class="post-title"><a href="../courses/java-generics/module-1-foundations.html">Module 1: Foundations - Core Concepts and Type Safety</a></h2>
-
-<p class="post-meta">
-  <span class="blog-tags">
-    &nbsp;
-    <i class="fa fa-tags"></i>
-      <a href="../tags/java.html">java</a>
-      <a href="../tags/generics.html">generics</a>
-  </span>
-</p>
-
-<div class="post-entry-container">
-  <div class="post-entry">
-    📖 Module Overview
-Welcome to the foundation of Java Generics! In this module, you'll discover why generics were introduced, understand the problems they solve, and learn the fundamental syntax that makes Java code safer and more expressive.
-🎯 Learning Objectives
-By the end of this module, you will:
-
-Understand the core problems that generics solve
-Eliminate raw types from your code completely
-App...
-    <p></p>
-    <a href="../courses/java-generics/module-1-foundations.html" class="post-read-more">[Read More]</a>
   </div>
 </div>
 </article>
@@ -875,6 +877,33 @@ Understand covariance, contravariance, and invariance in Java
 Mas...
     <p></p>
     <a href="../courses/java-generics/module-2-wildcards.html" class="post-read-more">[Read More]</a>
+  </div>
+</div>
+</article>
+<article class="post-preview">
+<h2 class="post-title"><a href="../courses/java-generics/module-1-foundations.html">Module 1: Foundations - Core Concepts and Type Safety</a></h2>
+
+<p class="post-meta">
+  <span class="blog-tags">
+    &nbsp;
+    <i class="fa fa-tags"></i>
+      <a href="../tags/java.html">java</a>
+      <a href="../tags/generics.html">generics</a>
+  </span>
+</p>
+
+<div class="post-entry-container">
+  <div class="post-entry">
+    📖 Module Overview
+Welcome to the foundation of Java Generics! In this module, you'll discover why generics were introduced, understand the problems they solve, and learn the fundamental syntax that makes Java code safer and more expressive.
+🎯 Learning Objectives
+By the end of this module, you will:
+
+Understand the core problems that generics solve
+Eliminate raw types from your code completely
+App...
+    <p></p>
+    <a href="../courses/java-generics/module-1-foundations.html" class="post-read-more">[Read More]</a>
   </div>
 </div>
 </article>

--- a/docs/tags/openspec.html
+++ b/docs/tags/openspec.html
@@ -86,6 +86,35 @@
 
 <div class="posts-list">
 <article class="post-preview">
+<h2 class="post-title"><a href="../blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.html">Validating hypotheses about Plinth workflow with a Benchmark Part 2</a></h2>
+
+<p class="post-meta">
+  <i class="fa fa-calendar-o"></i>
+  2026-09-05
+    &nbsp;
+    <i class="fa fa-pencil"></i>
+    MyRobot
+  <span class="blog-tags">
+    &nbsp;
+    <i class="fa fa-tags"></i>
+      <a href="../tags/blog.html">blog</a>
+      <a href="../tags/agents.html">agents</a>
+      <a href="../tags/skills.html">skills</a>
+      <a href="../tags/openspec.html">openspec</a>
+      <a href="../tags/performance.html">performance</a>
+      <a href="../tags/java.html">java</a>
+  </span>
+</p>
+
+<div class="post-entry-container">
+  <div class="post-entry">
+    This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. Part 1 built a benchmark that hands the same problem to several agent tools under briefs of increasing structure, logs every run as a validated JSON record, and uses those records to test three hypotheses about whether richer workflows actually pay off. The benchmark t...
+    <p></p>
+    <a href="../blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.html" class="post-read-more">[Read More]</a>
+  </div>
+</div>
+</article>
+<article class="post-preview">
 <h2 class="post-title"><a href="../blog/2026/08/release-0.18.0.html">What&apos;s new in Plinth 0.18.0?</a></h2>
 
 <p class="post-meta">

--- a/docs/tags/openspec.html
+++ b/docs/tags/openspec.html
@@ -108,7 +108,7 @@
 
 <div class="post-entry-container">
   <div class="post-entry">
-    This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. In Part 1 article, it showed the benchmark results around 4 scenarios:
+    This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. The Part 1 article showed the benchmark results across 4 scenarios:
 
 
 ScenarioWhat the agent gets
@@ -116,7 +116,7 @@ ScenarioWhat the agent gets
 
 scenario1A minimal README only — baseline, sparsest possible brief
 scenario2A full functional-requirements package: user story, Gherkin, OpenAPI, ADRs
-scenario3An Ope...
+scenario3An OpenSp...
     <p></p>
     <a href="../blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.html" class="post-read-more">[Read More]</a>
   </div>

--- a/docs/tags/openspec.html
+++ b/docs/tags/openspec.html
@@ -108,7 +108,15 @@
 
 <div class="post-entry-container">
   <div class="post-entry">
-    This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. Part 1 built a benchmark that hands the same problem to several agent tools under briefs of increasing structure, logs every run as a validated JSON record, and uses those records to test three hypotheses about whether richer workflows actually pay off. The benchmark t...
+    This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. In Part 1 article, it showed the benchmark results around 4 scenarios:
+
+
+ScenarioWhat the agent gets
+
+
+scenario1A minimal README only — baseline, sparsest possible brief
+scenario2A full functional-requirements package: user story, Gherkin, OpenAPI, ADRs
+scenario3An Ope...
     <p></p>
     <a href="../blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.html" class="post-read-more">[Read More]</a>
   </div>

--- a/docs/tags/performance.html
+++ b/docs/tags/performance.html
@@ -86,6 +86,35 @@
 
 <div class="posts-list">
 <article class="post-preview">
+<h2 class="post-title"><a href="../blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.html">Validating hypotheses about Plinth workflow with a Benchmark Part 2</a></h2>
+
+<p class="post-meta">
+  <i class="fa fa-calendar-o"></i>
+  2026-09-05
+    &nbsp;
+    <i class="fa fa-pencil"></i>
+    MyRobot
+  <span class="blog-tags">
+    &nbsp;
+    <i class="fa fa-tags"></i>
+      <a href="../tags/blog.html">blog</a>
+      <a href="../tags/agents.html">agents</a>
+      <a href="../tags/skills.html">skills</a>
+      <a href="../tags/openspec.html">openspec</a>
+      <a href="../tags/performance.html">performance</a>
+      <a href="../tags/java.html">java</a>
+  </span>
+</p>
+
+<div class="post-entry-container">
+  <div class="post-entry">
+    This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. Part 1 built a benchmark that hands the same problem to several agent tools under briefs of increasing structure, logs every run as a validated JSON record, and uses those records to test three hypotheses about whether richer workflows actually pay off. The benchmark t...
+    <p></p>
+    <a href="../blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.html" class="post-read-more">[Read More]</a>
+  </div>
+</div>
+</article>
+<article class="post-preview">
 <h2 class="post-title"><a href="../blog/2026/07/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-1.html">Validating hypotheses about Plinth workflow with a Benchmark Part 1</a></h2>
 
 <p class="post-meta">

--- a/docs/tags/performance.html
+++ b/docs/tags/performance.html
@@ -108,7 +108,7 @@
 
 <div class="post-entry-container">
   <div class="post-entry">
-    This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. In Part 1 article, it showed the benchmark results around 4 scenarios:
+    This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. The Part 1 article showed the benchmark results across 4 scenarios:
 
 
 ScenarioWhat the agent gets
@@ -116,7 +116,7 @@ ScenarioWhat the agent gets
 
 scenario1A minimal README only — baseline, sparsest possible brief
 scenario2A full functional-requirements package: user story, Gherkin, OpenAPI, ADRs
-scenario3An Ope...
+scenario3An OpenSp...
     <p></p>
     <a href="../blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.html" class="post-read-more">[Read More]</a>
   </div>

--- a/docs/tags/performance.html
+++ b/docs/tags/performance.html
@@ -108,7 +108,15 @@
 
 <div class="post-entry-container">
   <div class="post-entry">
-    This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. Part 1 built a benchmark that hands the same problem to several agent tools under briefs of increasing structure, logs every run as a validated JSON record, and uses those records to test three hypotheses about whether richer workflows actually pay off. The benchmark t...
+    This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. In Part 1 article, it showed the benchmark results around 4 scenarios:
+
+
+ScenarioWhat the agent gets
+
+
+scenario1A minimal README only — baseline, sparsest possible brief
+scenario2A full functional-requirements package: user story, Gherkin, OpenAPI, ADRs
+scenario3An Ope...
     <p></p>
     <a href="../blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.html" class="post-read-more">[Read More]</a>
   </div>

--- a/docs/tags/profiling.html
+++ b/docs/tags/profiling.html
@@ -117,33 +117,6 @@ With JFR, production evidence replaces g...
 </div>
 </article>
 <article class="post-preview">
-<h2 class="post-title"><a href="../courses/profile-memory-leak/module-3-analysis.html">Module 3: Analysis and Evidence Collection</a></h2>
-
-<p class="post-meta">
-  <span class="blog-tags">
-    &nbsp;
-    <i class="fa fa-tags"></i>
-      <a href="../tags/java.html">java</a>
-      <a href="../tags/profiling.html">profiling</a>
-  </span>
-</p>
-
-<div class="post-entry-container">
-  <div class="post-entry">
-    Systematic Analysis using @162-java-profiling-analyze
-⏱️ Duration: 2 hours
-🎯 Learning Objectives:
-- Master the systematic analysis framework from @162-java-profiling-analyze
-- Learn to categorize and prioritize performance issues using Impact/Effort scoring
-- Create structured documentation following professional templates
-- Develop cross-correlation analysis skills for multiple profiling results
-...
-    <p></p>
-    <a href="../courses/profile-memory-leak/module-3-analysis.html" class="post-read-more">[Read More]</a>
-  </div>
-</div>
-</article>
-<article class="post-preview">
 <h2 class="post-title"><a href="../courses/profile-memory-leak/module-2-profiling.html">Module 2: Hands-on Profiling with System Prompts</a></h2>
 
 <p class="post-meta">
@@ -273,6 +246,33 @@ Module 3:...
 - Set up monitoring and alerting for ongoing protect...
     <p></p>
     <a href="../courses/profile-memory-leak/module-4-refactoring.html" class="post-read-more">[Read More]</a>
+  </div>
+</div>
+</article>
+<article class="post-preview">
+<h2 class="post-title"><a href="../courses/profile-memory-leak/module-3-analysis.html">Module 3: Analysis and Evidence Collection</a></h2>
+
+<p class="post-meta">
+  <span class="blog-tags">
+    &nbsp;
+    <i class="fa fa-tags"></i>
+      <a href="../tags/java.html">java</a>
+      <a href="../tags/profiling.html">profiling</a>
+  </span>
+</p>
+
+<div class="post-entry-container">
+  <div class="post-entry">
+    Systematic Analysis using @162-java-profiling-analyze
+⏱️ Duration: 2 hours
+🎯 Learning Objectives:
+- Master the systematic analysis framework from @162-java-profiling-analyze
+- Learn to categorize and prioritize performance issues using Impact/Effort scoring
+- Create structured documentation following professional templates
+- Develop cross-correlation analysis skills for multiple profiling results
+...
+    <p></p>
+    <a href="../courses/profile-memory-leak/module-3-analysis.html" class="post-read-more">[Read More]</a>
   </div>
 </div>
 </article>

--- a/docs/tags/skills.html
+++ b/docs/tags/skills.html
@@ -86,6 +86,35 @@
 
 <div class="posts-list">
 <article class="post-preview">
+<h2 class="post-title"><a href="../blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.html">Validating hypotheses about Plinth workflow with a Benchmark Part 2</a></h2>
+
+<p class="post-meta">
+  <i class="fa fa-calendar-o"></i>
+  2026-09-05
+    &nbsp;
+    <i class="fa fa-pencil"></i>
+    MyRobot
+  <span class="blog-tags">
+    &nbsp;
+    <i class="fa fa-tags"></i>
+      <a href="../tags/blog.html">blog</a>
+      <a href="../tags/agents.html">agents</a>
+      <a href="../tags/skills.html">skills</a>
+      <a href="../tags/openspec.html">openspec</a>
+      <a href="../tags/performance.html">performance</a>
+      <a href="../tags/java.html">java</a>
+  </span>
+</p>
+
+<div class="post-entry-container">
+  <div class="post-entry">
+    This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. Part 1 built a benchmark that hands the same problem to several agent tools under briefs of increasing structure, logs every run as a validated JSON record, and uses those records to test three hypotheses about whether richer workflows actually pay off. The benchmark t...
+    <p></p>
+    <a href="../blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.html" class="post-read-more">[Read More]</a>
+  </div>
+</div>
+</article>
+<article class="post-preview">
 <h2 class="post-title"><a href="../blog/2026/08/release-0.18.0.html">What&apos;s new in Plinth 0.18.0?</a></h2>
 
 <p class="post-meta">

--- a/docs/tags/skills.html
+++ b/docs/tags/skills.html
@@ -108,7 +108,7 @@
 
 <div class="post-entry-container">
   <div class="post-entry">
-    This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. In Part 1 article, it showed the benchmark results around 4 scenarios:
+    This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. The Part 1 article showed the benchmark results across 4 scenarios:
 
 
 ScenarioWhat the agent gets
@@ -116,7 +116,7 @@ ScenarioWhat the agent gets
 
 scenario1A minimal README only — baseline, sparsest possible brief
 scenario2A full functional-requirements package: user story, Gherkin, OpenAPI, ADRs
-scenario3An Ope...
+scenario3An OpenSp...
     <p></p>
     <a href="../blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.html" class="post-read-more">[Read More]</a>
   </div>

--- a/docs/tags/skills.html
+++ b/docs/tags/skills.html
@@ -108,7 +108,15 @@
 
 <div class="post-entry-container">
   <div class="post-entry">
-    This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. Part 1 built a benchmark that hands the same problem to several agent tools under briefs of increasing structure, logs every run as a validated JSON record, and uses those records to test three hypotheses about whether richer workflows actually pay off. The benchmark t...
+    This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. In Part 1 article, it showed the benchmark results around 4 scenarios:
+
+
+ScenarioWhat the agent gets
+
+
+scenario1A minimal README only — baseline, sparsest possible brief
+scenario2A full functional-requirements package: user story, Gherkin, OpenAPI, ADRs
+scenario3An Ope...
     <p></p>
     <a href="../blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.html" class="post-read-more">[Read More]</a>
   </div>

--- a/docs/tags/system-prompts.html
+++ b/docs/tags/system-prompts.html
@@ -86,34 +86,6 @@
 
 <div class="posts-list">
 <article class="post-preview">
-<h2 class="post-title"><a href="../courses/system-prompts-java/module-5-performance.html">Module 5: Performance - Optimization &amp; Profiling</a></h2>
-
-<p class="post-meta">
-  <span class="blog-tags">
-    &nbsp;
-    <i class="fa fa-tags"></i>
-      <a href="../tags/java.html">java</a>
-      <a href="../tags/system-prompts.html">system-prompts</a>
-  </span>
-</p>
-
-<div class="post-entry-container">
-  <div class="post-entry">
-    🎯 Learning Objectives
-By the end of this module, you will:
-
-Create JMeter performance tests using @151-java-performance-jmeter
-Profile applications comprehensively using @161-java-profiling-detect
-Analyze performance bottlenecks using @162-java-profiling-analyze
-Compare performance improvements using @164-java-profiling-compare
-Benchmark code with JMH for micro-optimizations
-Apply systematic perfo...
-    <p></p>
-    <a href="../courses/system-prompts-java/module-5-performance.html" class="post-read-more">[Read More]</a>
-  </div>
-</div>
-</article>
-<article class="post-preview">
 <h2 class="post-title"><a href="../courses/system-prompts-java/module-4-modern-java.html">Module 4: Modern Java - Advanced Language Features</a></h2>
 
 <p class="post-meta">
@@ -311,6 +283,34 @@ Create maintainable, professional documentation that scales with projects
 Duration: 3 ...
     <p></p>
     <a href="../courses/system-prompts-java/module-6-documentation.html" class="post-read-more">[Read More]</a>
+  </div>
+</div>
+</article>
+<article class="post-preview">
+<h2 class="post-title"><a href="../courses/system-prompts-java/module-5-performance.html">Module 5: Performance - Optimization &amp; Profiling</a></h2>
+
+<p class="post-meta">
+  <span class="blog-tags">
+    &nbsp;
+    <i class="fa fa-tags"></i>
+      <a href="../tags/java.html">java</a>
+      <a href="../tags/system-prompts.html">system-prompts</a>
+  </span>
+</p>
+
+<div class="post-entry-container">
+  <div class="post-entry">
+    🎯 Learning Objectives
+By the end of this module, you will:
+
+Create JMeter performance tests using @151-java-performance-jmeter
+Profile applications comprehensively using @161-java-profiling-detect
+Analyze performance bottlenecks using @162-java-profiling-analyze
+Compare performance improvements using @164-java-profiling-compare
+Benchmark code with JMH for micro-optimizations
+Apply systematic perfo...
+    <p></p>
+    <a href="../courses/system-prompts-java/module-5-performance.html" class="post-read-more">[Read More]</a>
   </div>
 </div>
 </article>

--- a/site-generator/content/blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.md
+++ b/site-generator/content/blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.md
@@ -1,0 +1,293 @@
+title=Validating hypotheses about Plinth workflow with a Benchmark Part 2
+date=2026-09-05
+type=post
+tags=blog,agents,skills,openspec,performance,java
+author=MyRobot
+status=published
+~~~~~~
+
+This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. [Part 1](https://jabrena.github.io/plinth/blog/2026/07/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-1.html) built a [benchmark](https://github.com/jabrena/plinth/tree/main/benchmarks) that hands the same problem to several agent tools under briefs of increasing structure, logs every run as a validated JSON record, and uses those records to test three hypotheses about whether richer workflows actually pay off. The benchmark tried to validate the followed Hyphoteses:
+
+- **Hypothesis 1:** Richer workflows reduce implementation rework.
+- **Hypothesis 2:** Delegation workflows encourage autonomous use of reusable skills.
+- **Hypothesis 3:** Written architectural decisions improve consistency.
+
+Part 1 ended with one scenario clearly ahead — but it could not say *why*, because that scenario changed two things at once: the OpenSpec plan and the orchestration command that executes it. Part 2 sets out to separate them. The goals here are concrete:
+
+- **Isolate the command from the plan.** A new `scenario5` runs the exact same OpenSpec technical plan as `scenario4`, implemented directly, with `/implement-spec` and its agents forbidden. `scenario4` vs `scenario5` is then a clean A/B: identical plan, orchestration the only variable.
+- **Check whether the answer is problem-dependent.** A second problem — a persistence-and-scheduling "Greek Gods API" — joins the original fan-out-and-sum one, so every finding can be read per problem.
+- **Re-test all three hypotheses on a much larger dataset.** The corpus has grown from 54 runs to 217 non-template records across two problems, five scenarios, four tools, and a spread of models, with outlier trimming applied consistently.
+
+## What is new in Part 2
+
+Two additions to the harness:
+
+<table>
+<thead>
+<tr><th>Addition</th><th>What it is</th></tr>
+</thead>
+<tbody>
+<tr><td><code>scenario5</code></td><td>The <strong>same</strong> OpenSpec technical plan as <code>scenario4</code> — same <code>specs/technical-requirements/openspec/</code> tree — implemented <strong>directly</strong>. <code>/implement-spec</code> is forbidden; there is no mandated agent or skill. Agents and skills are still <em>allowed</em> if the tool reaches for them on its own.</td></tr>
+<tr><td><a href="https://github.com/jabrena/plinth/tree/main/benchmarks/problem2">Problem 2</a></td><td>The <strong>Greek Gods API</strong> (<a href="https://github.com/jabrena/latency-problems/blob/master/docs/problem5/README.md">latency-problems Problem 5</a>): a REST API that periodically syncs a Greek-gods catalogue from a third-party service into a relational database via Flyway. It is a persistence-and-scheduling problem, not a pure fan-out-and-sum one.</td></tr>
+</tbody>
+</table>
+
+So `scenario4` (**S4**, orchestrated) versus `scenario5` (**S5**, direct) is a clean A/B: identical plan, and the only difference is whether `/implement-spec` and its agents run. Doing this across two different problems shows whether the answer is problem-dependent.
+
+The dataset has also grown a lot — from the 54 runs in Part 1 to **217 non-template result records** across both problems, five scenarios, and tools including `cursor`, `codex`, `claude-code`, and `github-copilot` on a spread of models (Grok 4.5, GPT-5.x, Claude Sonnet 5 / Opus 5 / Fable 5, Composer).
+
+### How long the two problems actually take
+
+Those fences come from the full per-problem wall-clock distribution — every scenario, tool, and model pooled together. It is worth looking at that distribution on its own, because it answers the question people ask before they ask anything about workflows: *how long is one of these runs?*
+
+<table>
+<thead>
+<tr><th>Problem</th><th>Positive timings</th><th>Q1</th><th>Median</th><th>Q3</th><th>IQR</th><th>Tukey upper fence</th><th>High outliers</th><th>Non-outlier range</th></tr>
+</thead>
+<tbody>
+<tr><td><strong>Problem 1</strong> (God Analysis)</td><td>117</td><td>307 s (5:07 min)</td><td>560 s (9:20 min)</td><td>1,003 s (16:43 min)</td><td>696 s</td><td>2,047 s (34:07 min)</td><td>7</td><td><strong>51–1,908 s</strong> (0:51–31:48 min)</td></tr>
+<tr><td><strong>Problem 2</strong> (Greek Gods)</td><td>98</td><td>366 s (6:06 min)</td><td>665 s (11:05 min)</td><td>1,400 s (23:20 min)</td><td>1,034 s</td><td>2,951 s (49:11 min)</td><td>2</td><td><strong>136–2,446 s</strong> (2:16–40:46 min)</td></tr>
+</tbody>
+</table>
+
+Problem 2 is the harder job by every measure: its median run is about two minutes longer, its middle 50% of runs span **6 to 23 minutes** against Problem 1's 5 to 17, and its spread (IQR) is half as wide again. The persistence-plus-scheduling problem simply takes more building than the fan-out-and-sum one — a useful planning bound in its own right, independent of which workflow produced it. It also explains why the two Tukey fences land so far apart (**2,047 s for Problem 1**, **2,951 s for Problem 2**), and why a run that would be a clear outlier on Problem 1 can be an ordinary long run on Problem 2.
+
+After trimming, the current-workflow cohort (S4 = only `plinth-*` agents recorded; S5 = no legacy `robot-*` agent) is:
+
+<table>
+<thead>
+<tr><th></th><th>Raw records</th><th>Wall-time outliers</th><th>Retained</th></tr>
+</thead>
+<tbody>
+<tr><td><strong>S4</strong> (orchestrated)</td><td>56</td><td>6</td><td><strong>50</strong></td></tr>
+<tr><td><strong>S5</strong> (direct)</td><td>71</td><td>3</td><td><strong>68</strong></td></tr>
+</tbody>
+</table>
+
+## Hypothesis 1 revisited: does the command reduce rework once you already have the plan?
+
+Here is the pooled, trimmed picture:
+
+<table>
+<thead>
+<tr><th>Cohort</th><th>Runs</th><th>Pass rate</th><th>Avg rework turns</th><th>Zero-rework runs</th><th>Median wall time</th></tr>
+</thead>
+<tbody>
+<tr><td><strong>S4</strong> — <code>/implement-spec</code> + agents</td><td>50</td><td>49/50 (98%)</td><td><strong>0.76</strong></td><td>44%</td><td>15:52 min (952 s)</td></tr>
+<tr><td><strong>S5</strong> — direct implementation</td><td>68</td><td>65/68 (96%)</td><td>1.21</td><td>35%</td><td><strong>10:12 min</strong> (612 s)</td></tr>
+</tbody>
+</table>
+
+On the pooled numbers S4 comes out ahead on every reliability column — higher pass rate, lower average rework, more zero-rework runs — while S5 is about **36% faster by median wall time**. That is a real trade-off, not a free win: the command costs you roughly a third of your wall-clock budget to buy a lower correction rate.
+
+But "pooled" hides an interaction, and the per-problem split is where it shows up:
+
+<table>
+<thead>
+<tr><th>Problem</th><th>Cohort</th><th>Pass rate</th><th>Avg rework</th><th>Zero-rework</th><th>Median wall</th></tr>
+</thead>
+<tbody>
+<tr><td rowspan="2">Problem 1 (God Analysis)</td><td>S4</td><td>17/18</td><td><strong>0.78</strong></td><td>39%</td><td>14:32 min (872 s)</td></tr>
+<tr><td>S5</td><td>28/30</td><td>1.00</td><td><strong>50%</strong></td><td><strong>9:15 min</strong> (555 s)</td></tr>
+<tr><td rowspan="2">Problem 2 (Greek Gods)</td><td>S4</td><td><strong>32/32</strong></td><td><strong>0.75</strong></td><td><strong>47%</strong></td><td>18:11 min (1,091 s)</td></tr>
+<tr><td>S5</td><td>37/38</td><td>1.37</td><td>24%</td><td><strong>11:05 min</strong> (665 s)</td></tr>
+</tbody>
+</table>
+
+On **Problem 2** — the database problem — S4 is cleanly better on reliability: a perfect 32/32 pass rate, roughly half the average rework, and double the zero-rework share. It also pays for it with a bigger latency premium here (median 1,091 s vs 665 s, about 64% slower).
+
+On **Problem 1**, the orchestration advantage mostly evaporates. Pass rates are within a run of each other, S5 has *more* zero-rework runs, and S5 is materially faster. S4 keeps a slight edge on average rework and nothing else.
+
+### It is also model-dependent
+
+Breaking the trimmed cohort down by model family shows the rework advantage is not universal:
+
+<table>
+<thead>
+<tr><th>Model family</th><th>Retained runs (S4 / S5)</th><th>What the data shows</th></tr>
+</thead>
+<tbody>
+<tr><td>Cursor Grok 4.5</td><td>19 / 20</td><td>Every run passes. S5 has <em>lower</em> rework (0.35 vs 0.68), more zero-rework runs (70% vs 32%), and is faster. A clean counterexample to a model-independent S4 benefit.</td></tr>
+<tr><td>Codex GPT-5.x</td><td>13 / 23</td><td>S4 13/13 pass at 1.15 rework; S5 22/23 at 2.04. S5 about 41% faster. Favours S4 on reliability, S5 on speed.</td></tr>
+<tr><td>Claude Sonnet 5</td><td>13 / 18</td><td>S4 12/13 pass, 0.62 rework, 62% zero-rework; S5 16/18, 1.11 rework, 28% zero-rework. S4-leaning on reliability; S5 only ~11% faster.</td></tr>
+</tbody>
+</table>
+
+**Hypothesis 1 holds only as a conditional trade-off.** Orchestration lowers the correction rate on Problem 2 and for Codex / Sonnet 5 / Fable — always at a latency cost. On Problem 1 and for the large Grok cohort, direct implementation matches or beats it.
+
+## Hypothesis 2 revisited: what actually makes an agent use your skills?
+
+Part 1 showed `scenario4` runs pulling in far more of the skill/command/agent library than the sparser scenarios — but it could not tell whether that was the OpenSpec documents or the delegation wiring doing it. `scenario5` answers it directly, because it hands the tool the exact same OpenSpec plan with the delegation wiring removed.
+
+<table>
+<thead>
+<tr><th>Cohort</th><th>Runs</th><th>Avg skills used</th><th>Avg agents used</th><th>Runs with zero agents</th></tr>
+</thead>
+<tbody>
+<tr><td><strong>S4</strong> (<code>/implement-spec</code>)</td><td>50</td><td><strong>14.2</strong></td><td><strong>2.00</strong></td><td>0 / 50</td></tr>
+<tr><td><strong>S5</strong> (direct, same plan)</td><td>68</td><td>6.0</td><td>0.26</td><td>51 / 68</td></tr>
+</tbody>
+</table>
+
+Same plan, an order of magnitude less delegation. Every S4 run records exactly two agents (the tech-lead plus a framework coder); three quarters of S5 runs record **no agent at all**, and the skill count roughly halves. The documents do not trigger the machinery — the command does.
+
+Those pooled averages hide a wide spread by tool and model. Under S4 the delegation command forces the issue — every retained run logs exactly two agents whatever the tool — so the only thing left to vary is how many *skills* each run pulls in behind the command. Under S5, with nothing mandated, both numbers are the tool's own choice:
+
+<table>
+<thead>
+<tr><th>Tool · model</th><th>S4 avg skills (runs)</th><th>S5 avg skills (runs)</th><th>S5 avg agents</th><th>S5 runs with ≥1 agent</th></tr>
+</thead>
+<tbody>
+<tr><td><code>codex</code> · GPT-5.x</td><td><strong>16.8</strong> (13)</td><td>7.4 (23)</td><td>0.00</td><td>0 / 23</td></tr>
+<tr><td><code>cursor</code> · Grok 4.5</td><td>13.2 (19)</td><td><strong>7.7</strong> (20)</td><td><strong>0.55</strong></td><td>11 / 20</td></tr>
+<tr><td><code>claude-code</code> · Sonnet 5</td><td>14.0 (13)</td><td>3.3 (18)</td><td>0.17</td><td>2 / 18</td></tr>
+</tbody>
+</table>
+
+Two things stand out. First, **self-directed skill use splits by tool, not by model family**: left alone, `cursor` (Grok 4.5) and `codex` (GPT-5.x) reach for 7–8 skills a run, while every `claude-code` model settles around 3 — more than double on the Cursor/Codex side. Second, **skills and agents are separate reflexes**: `codex` pulls plenty of skills but never once spawns a sub-agent unprompted (0 / 23), whereas `cursor` with Grok delegates in about half its runs and `claude-code` with Fable every time on a tiny sample. The one- and two-run rows (Composer, Opus 5, Fable 5) are too thin to lean on; the Grok 4.5, GPT-5.x and Sonnet 5 rows carry the weight. All six S5 "≥1 agent" counts add up to the 17 self-directed-agent runs noted below.
+
+There is a caveat that keeps S5 from being a pure "no-agent control": **17 of 68** retained S5 runs still reached for at least one agent on their own initiative (11 on Problem 1, 6 on Problem 2). So the contrast is really *mandated* full orchestration versus *optional* self-directed tool use, not orchestration versus nothing.
+
+**Hypothesis 2 is supported.** Autonomous skill and agent use tracks the delegation command, not the richness of the specification the agent is handed.
+
+## Hypothesis 3 revisited: does the architecture survive without the command?
+
+Part 1's finding was that the hexagonal scaffold in `scenario4` came from the written `design.md`, not from any tool's taste. If that is true, S5 should produce the same structure from the same plan — even with no orchestration.
+
+It does. Of the trimmed snapshots, **an ArchUnit boundary test (`HexagonalArchitectureTest`) is present in 50/50 S4 runs and 67/68 S5 runs.** The one exception is a single Codex S5 run that never wrote the test file.
+
+Holding the tool and commit constant (`cursor` / Grok 4.5, same Problem 2 commit), the S4 and S5 trees are near-identical — same ports-and-adapters split, same class names:
+
+**S4 — orchestrated (`/implement-spec`):**
+
+```text
+info/jab/ms/
+├── GreekGodsApplication.java
+├── adapter/
+│   ├── in/
+│   │   ├── rest/
+│   │   │   ├── GreekGodResource.java
+│   │   │   ├── ProblemDetails.java
+│   │   │   └── ProblemDetailsExceptionMapper.java
+│   │   └── scheduler/
+│   │       └── GodUpdater.java
+│   └── out/
+│       ├── http/
+│       │   ├── GodSourceRestClient.java
+│       │   └── RestGodSourceClient.java
+│       └── persistence/
+│           └── JdbcGreekGodRepository.java
+├── application/
+│   ├── GetGreekGodsUseCase.java
+│   ├── SynchronizeGreekGodsUseCase.java
+│   └── port/
+│       ├── in/  {QueryGreekGods, SynchronizeGreekGods}
+│       └── out/ {GodSourceClient, GreekGodRepository}
+└── domain/
+    └── GreekGod.java
+
+test/.../architecture/HexagonalArchitectureTest.java
+```
+
+**S5 — direct, same plan:**
+
+```text
+info/jab/ms/
+├── GreekGodsApplication.java
+├── adapter/
+│   ├── in/
+│   │   ├── rest/
+│   │   │   ├── GreekGodResource.java
+│   │   │   └── ProblemDetailsExceptionMapper.java
+│   │   └── scheduler/
+│   │       └── GodUpdater.java
+│   └── out/
+│       ├── http/
+│       │   ├── MyJsonServerApi.java
+│       │   └── RestGodSourceClient.java
+│       └── persistence/
+│           └── JdbcGreekGodRepository.java
+├── application/
+│   ├── GetGreekGodsUseCase.java
+│   ├── SynchronizeGreekGodsUseCase.java
+│   └── port/
+│       ├── in/  {QueryGreekGods, SynchronizeGreekGods}
+│       └── out/ {GodSourceClient, GreekGodRepository}
+└── domain/
+    └── GreekGod.java
+
+test/.../architecture/HexagonalArchitectureTest.java
+```
+
+The differences are cosmetic (a differently named HTTP client, a spare `ProblemDetails` record, where the acceptance tests are parked). The `adapter/in`, `adapter/out`, `application/port/{in,out}`, `domain` skeleton and the boundary test are identical — because they are spelled out in the OpenSpec input both scenarios receive.
+
+### A side check: how many test classes each run leaves behind
+
+The boundary test is prescribed; the rest of the test suite is not. Every retained run's snapshot carries the full `src/` tree, so the test files each run wrote can be counted — and because the trees arrive in several `tree`/flat formats, this counts **distinct `*Test` / `*IT` / `*AT` Java class names** rather than reconstructing the directory layout. Setting aside the `HexagonalArchitectureTest`-style boundary test above (present in nearly every run of both cohorts), the test classes the implementer chose to add break down as:
+
+<table>
+<thead>
+<tr><th>Problem</th><th>S4 — median (mean), runs</th><th>S5 — median (mean), runs</th></tr>
+</thead>
+<tbody>
+<tr><td><strong>Problem 1</strong> (God Analysis)</td><td>6 (6.4), n=18</td><td>5 (6.0), n=30</td></tr>
+<tr><td><strong>Problem 2</strong> (Greek Gods)</td><td><strong>5.5 (5.1)</strong>, n=32</td><td>4 (3.8), n=38</td></tr>
+<tr><td>Pooled</td><td>6 (5.6), n=50</td><td>4 (4.8), n=68</td></tr>
+</tbody>
+</table>
+
+On **Problem 1** the two workflows land within half a test class of each other. On **Problem 2** the orchestrated runs carry about **one extra test class apiece** (median 5.5 vs 4, mean 5.1 vs 3.8) — the same problem where S4 also cut rework in half and hit a perfect pass rate. Counting the boundary test back in keeps the shape: 6.5 vs 5 median on Problem 2, 7 vs 6 on Problem 1. So orchestration's structural fingerprint is not in the *architecture* — that is contractual — but in a slightly thicker test layer on the harder problem.
+
+The usual caveat applies: this is **file presence**. A `*Test.java` in the tree is not proof it compiles, runs, or asserts anything — the single acceptance flag is still the only execution signal in the dataset.
+
+### Where orchestration does leave a fingerprint: the Maven build
+
+Architecture is contractual, but the `pom.xml` is not fully specified, and that is where the two workflows differ — a little. Decoding and parsing every retained Problem 2 POM (all 70 are strict-Base64, well-formed XML, Java 25, and import the Quarkus BOM):
+
+<table>
+<thead>
+<tr><th>POM property</th><th>S4 (32 POMs)</th><th>S5 (38 POMs)</th></tr>
+</thead>
+<tbody>
+<tr><td>Core REST / REST-client / PostgreSQL / Flyway / scheduler stack</td><td>32/32</td><td>38/38</td></tr>
+<tr><td>Complete, version-pinned four-plugin lifecycle</td><td><strong>28/32</strong></td><td>26/38</td></tr>
+<tr><td><code>quarkus</code> application packaging (rest are <code>jar</code>)</td><td>18/32</td><td>21/38</td></tr>
+<tr><td>SmallRye OpenAPI dependency</td><td>31/32</td><td>30/38</td></tr>
+<tr><td>ArchUnit dependency</td><td>32/32</td><td>37/38</td></tr>
+<tr><td>Native-build profile</td><td>15/32</td><td>18/38</td></tr>
+<tr><td>Custom repositories / multi-module</td><td>0/32</td><td>0/38</td></tr>
+<tr><td>Production / test / error-named Java files (means)</td><td>16.3 / 6.5 / 3.7</td><td>15.5 / 5.7 / 3.2</td></tr>
+</tbody>
+</table>
+
+S4 pins the full Compiler / Surefire / Failsafe / Quarkus plugin set a bit more often (28/32 vs 26/38) and writes marginally more production and test files — a **5–15% edge**, not the large "assurance surface" gap an earlier read of the data suggested, and file presence still says nothing about whether those tests execute. On everything else the two are within a rounding error of each other. Packaging is a coin flip in *both* workflows: only about half of each cohort ships a `quarkus` application POM, the rest fall back to plain `jar`.
+
+The bigger story in the POMs is drift that neither workflow controls. Retained Quarkus platform versions span **3.27.0 to 3.39.1**, and same-commit S4/S5 pairs sometimes pick different platform versions. A recurring set of POMs declares both `quarkus-rest` and `quarkus-rest-jackson`, or adds `quarkus-agroal` next to a JDBC driver that already pulls it in; several mix `quarkus-junit` with the older `quarkus-junit5-*` coordinate family. None of that is caused by the workflow — it is the agents choosing dependencies run to run — but it is exactly the kind of variance a benchmark has to normalize before it can compare anything downstream.
+
+**Hypothesis 3 is supported, with a sharper conclusion than Part 1.** Project shape — framework, layering, boundary test — is not an orchestration effect at all; it is a written-decision effect, reproduced just as reliably by direct implementation because the OpenSpec input prescribes it. Whatever value `/implement-spec` adds shows up in execution discipline and correction cycles, not in project structure.
+
+## Takeaways
+
+Across two problems, five scenarios and 118 retained current-workflow runs, the S4-vs-S5 A/B is clean enough to say what `/implement-spec` does and does not buy once the OpenSpec plan already exists.
+
+**Hypothesis 1 — orchestration reduces rework beyond the written plan: conditionally supported.**
+The command lowers the correction rate, but only where the work is hard. On Problem 2 — persistence, scheduling, a migration — S4 is unambiguously ahead: 32/32 pass, half the average rework (0.75 vs 1.37), double the zero-rework share (47% vs 24%), and about one extra test class per run. On Problem 1, the fan-out-and-sum task, the gap closes: pass rates tie, S5 posts *more* zero-rework runs (50% vs 39%), and S5 is faster. The price is charged whether or not the benefit shows up — S5 is ~36% faster by median wall time, and S4 produced wall-time outliers at more than twice the rate (6 of 56 vs 3 of 71). It is model-shaped too: clear help for Codex, Sonnet 5 and Fable, break-even or worse for the large Cursor/Grok cohort. Reach for `/implement-spec` on integration-heavy work, not by default.
+
+**Hypothesis 2 — the delegation command, not the specification, drives skill and agent use: supported.**
+Given the identical `scenario4` plan with the orchestration stripped out, S5 runs use half the skills (6.0 vs 14.2) and almost no agents (0.26 vs 2.00 per run; 51 of 68 use none at all). Richer documents do not pull the library in — the command does. What the tools do unprompted splits by *tool*, not model family: `cursor`/Grok and `codex`/GPT-5.x self-invoke 7–8 skills a run while every `claude-code` model sits near 3, and `codex` never once spawns a sub-agent on its own. "Will my skill get used" today depends more on which tool is driving than on how the task is written.
+
+**Hypothesis 3 — written architecture holds regardless of who executes: supported, and narrower than Part 1 implied.**
+The hexagonal scaffold and the ArchUnit boundary test appear in 67 of 68 direct runs, class-for-class identical to the orchestrated ones, because the OpenSpec input spells them out. Orchestration's only structural fingerprint is a slightly fuller Maven lifecycle (28/32 vs 26/38 pinning all four plugins) and ~5–15% more source and test files — not architecture. What *neither* workflow controls is the dependency graph: Quarkus platform versions from 3.27.0 to 3.39.1, an H2 test driver in roughly half the POMs either way, redundant `quarkus-rest*` / `quarkus-agroal` declarations, mixed JUnit coordinates, and a `jar`-vs-`quarkus` packaging coin flip in both cohorts.
+
+**The load-bearing caveat.** Every number here rests on file presence plus a single pass/fail flag. A `*Test.java` in the tree is not a test that compiles, runs, or asserts anything, and `mvn verify` output is never captured. Until that closes, "less rework" means "the acceptance check went green in fewer turns", not "the code is more correct".
+
+## Next steps
+
+The data points at a handful of concrete changes to `/implement-spec`, each tied to a finding above:
+
+1. **Cut the latency — scale orchestration to the task.** The full tech-lead + framework-coder fan-out runs on every task, but the rework payoff only lands on the integration-heavy problem; on Problem 1 it buys nothing and still costs ~36% more wall time and more than twice the wall-time-outlier rate. Grade the task up front — integration count, persistence, migrations, concurrency, external services — and run the full fan-out only above a threshold. Below it, a single implementation pass plus one verification checkpoint should match it for far less time.
+2. **Find and keep only the active ingredient.** An S4 run pulls ~14 skills and 2 agents; the correction-rate benefit may come from a single verification pass. Log which sub-step fired and what each one caught, then drop — or background — the steps that never move rework.
+
+## Share your insights
+
+Share findings or raise questions about the harness itself on [GitHub Discussions](https://github.com/jabrena/plinth/discussions).

--- a/site-generator/content/blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.md
+++ b/site-generator/content/blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.md
@@ -6,13 +6,27 @@ author=MyRobot
 status=published
 ~~~~~~
 
-This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. [Part 1](https://jabrena.github.io/plinth/blog/2026/07/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-1.html) built a [benchmark](https://github.com/jabrena/plinth/tree/main/benchmarks) that hands the same problem to several agent tools under briefs of increasing structure, logs every run as a validated JSON record, and uses those records to test three hypotheses about whether richer workflows actually pay off. The benchmark tried to validate the followed Hyphoteses:
+This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. In [Part 1](https://jabrena.github.io/plinth/blog/2026/07/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-1.html) article, it showed the [benchmark](https://github.com/jabrena/plinth/tree/main/benchmarks) results around 4 scenarios:
+
+<table>
+<thead>
+<tr><th>Scenario</th><th>What the agent gets</th></tr>
+</thead>
+<tbody>
+<tr><td><code>scenario1</code></td><td>A minimal README only — baseline, sparsest possible brief</td></tr>
+<tr><td><code>scenario2</code></td><td>A full functional-requirements package: user story, Gherkin, OpenAPI, ADRs</td></tr>
+<tr><td><code>scenario3</code></td><td>An OpenSpec change created by the official <a href="https://www.skills.sh/fission-ai/openspec/openspec-propose"><code>openspec-propose</code></a> skill using as input the same functional requirements from scenario 2.</td></tr>
+<tr><td><code>scenario4</code></td><td>An OpenSpec change created by the Plinth skill <code>/create-spec</code> and enriched with <code>/explore-design</code> and finally implemented via <code>/implement-spec</code>.</td></tr>
+</tbody>
+</table>
+
+The benchmark tried to validate the followed Hyphoteses:
 
 - **Hypothesis 1:** Richer workflows reduce implementation rework.
 - **Hypothesis 2:** Delegation workflows encourage autonomous use of reusable skills.
 - **Hypothesis 3:** Written architectural decisions improve consistency.
 
-Part 1 ended with one scenario clearly ahead — but it could not say *why*, because that scenario changed two things at once: the OpenSpec plan and the orchestration command that executes it. Part 2 sets out to separate them. The goals here are concrete:
+Part 1 ended with a clear result — implementing a problem from a written specification pays off — and one scenario clearly ahead of the rest. But it could not say *why* that scenario won, because it changed two things at once: the OpenSpec plan and the orchestration command that executes it. Part 2 sets out to separate them. The goals here are concrete:
 
 - **Isolate the command from the plan.** A new `scenario5` runs the exact same OpenSpec technical plan as `scenario4`, implemented directly, with `/implement-spec` and its agents forbidden. `scenario4` vs `scenario5` is then a clean A/B: identical plan, orchestration the only variable.
 - **Check whether the answer is problem-dependent.** A second problem — a persistence-and-scheduling "Greek Gods API" — joins the original fan-out-and-sum one, so every finding can be read per problem.
@@ -20,19 +34,33 @@ Part 1 ended with one scenario clearly ahead — but it could not say *why*, bec
 
 ## What is new in Part 2
 
-Two additions to the harness:
+Two additions to the harness: a new scenario, and a second problem.
+
+**The two scenarios under comparison:**
 
 <table>
 <thead>
-<tr><th>Addition</th><th>What it is</th></tr>
+<tr><th>Scenario</th><th>How the plan is implemented</th></tr>
 </thead>
 <tbody>
-<tr><td><code>scenario5</code></td><td>The <strong>same</strong> OpenSpec technical plan as <code>scenario4</code> — same <code>specs/technical-requirements/openspec/</code> tree — implemented <strong>directly</strong>. <code>/implement-spec</code> is forbidden; there is no mandated agent or skill. Agents and skills are still <em>allowed</em> if the tool reaches for them on its own.</td></tr>
-<tr><td><a href="https://github.com/jabrena/plinth/tree/main/benchmarks/problem2">Problem 2</a></td><td>The <strong>Greek Gods API</strong> (<a href="https://github.com/jabrena/latency-problems/blob/master/docs/problem5/README.md">latency-problems Problem 5</a>): a REST API that periodically syncs a Greek-gods catalogue from a third-party service into a relational database via Flyway. It is a persistence-and-scheduling problem, not a pure fan-out-and-sum one.</td></tr>
+<tr><td><code>scenario4</code> (<strong>S4</strong>, orchestrated)</td><td>The OpenSpec technical plan from <code>/create-spec</code> + <code>/explore-design</code>, implemented through <code>/implement-spec</code> — which delegates to <code>@plinth-tech-lead</code> and a framework-specific coder agent. Full orchestration is <strong>mandated</strong>.</td></tr>
+<tr><td><code>scenario5</code> (<strong>S5</strong>, direct)</td><td>The <strong>same</strong> OpenSpec technical plan as <code>scenario4</code> — same <code>specs/technical-requirements/openspec/</code> tree — implemented <strong>directly</strong>. <code>/implement-spec</code> is forbidden; there is no mandated agent or skill. Agents and skills are still <em>allowed</em> if the tool reaches for them on its own.</td></tr>
 </tbody>
 </table>
 
-So `scenario4` (**S4**, orchestrated) versus `scenario5` (**S5**, direct) is a clean A/B: identical plan, and the only difference is whether `/implement-spec` and its agents run. Doing this across two different problems shows whether the answer is problem-dependent.
+**The two problems the A/B runs on:**
+
+<table>
+<thead>
+<tr><th>Problem</th><th>What it is</th></tr>
+</thead>
+<tbody>
+<tr><td><a href="https://github.com/jabrena/plinth/tree/main/benchmarks/problem1">Problem 1</a> — God Analysis API</td><td>The original benchmark problem (<a href="https://github.com/jabrena/latency-problems/blob/master/docs/problem1/README.md">latency-problems Problem 1</a>): a REST API that fans out to a third-party service and aggregates the results. A pure <strong>fan-out-and-sum</strong> problem, carried over from Part 1.</td></tr>
+<tr><td><a href="https://github.com/jabrena/plinth/tree/main/benchmarks/problem2">Problem 2</a> — Greek Gods API</td><td>New in Part 2 (<a href="https://github.com/jabrena/latency-problems/blob/master/docs/problem5/README.md">latency-problems Problem 5</a>): a REST API that periodically syncs a Greek-gods catalogue from a third-party service into a relational database via Flyway. A <strong>persistence-and-scheduling</strong> problem, not a pure fan-out-and-sum one.</td></tr>
+</tbody>
+</table>
+
+So `scenario4` (**S4**, orchestrated) versus `scenario5` (**S5**, direct) is a clean A/B: identical plan, and the only difference is whether `/implement-spec` and its agents run. Running that A/B across both problems shows whether the answer is problem-dependent.
 
 The dataset has also grown a lot — from the 54 runs in Part 1 to **217 non-template result records** across both problems, five scenarios, and tools including `cursor`, `codex`, `claude-code`, and `github-copilot` on a spread of models (Grok 4.5, GPT-5.x, Claude Sonnet 5 / Opus 5 / Fable 5, Composer).
 
@@ -51,18 +79,6 @@ Those fences come from the full per-problem wall-clock distribution — every sc
 </table>
 
 Problem 2 is the harder job by every measure: its median run is about two minutes longer, its middle 50% of runs span **6 to 23 minutes** against Problem 1's 5 to 17, and its spread (IQR) is half as wide again. The persistence-plus-scheduling problem simply takes more building than the fan-out-and-sum one — a useful planning bound in its own right, independent of which workflow produced it. It also explains why the two Tukey fences land so far apart (**2,047 s for Problem 1**, **2,951 s for Problem 2**), and why a run that would be a clear outlier on Problem 1 can be an ordinary long run on Problem 2.
-
-After trimming, the current-workflow cohort (S4 = only `plinth-*` agents recorded; S5 = no legacy `robot-*` agent) is:
-
-<table>
-<thead>
-<tr><th></th><th>Raw records</th><th>Wall-time outliers</th><th>Retained</th></tr>
-</thead>
-<tbody>
-<tr><td><strong>S4</strong> (orchestrated)</td><td>56</td><td>6</td><td><strong>50</strong></td></tr>
-<tr><td><strong>S5</strong> (direct)</td><td>71</td><td>3</td><td><strong>68</strong></td></tr>
-</tbody>
-</table>
 
 ## Hypothesis 1 revisited: does the command reduce rework once you already have the plan?
 
@@ -147,6 +163,89 @@ Those pooled averages hide a wide spread by tool and model. Under S4 the delegat
 Two things stand out. First, **self-directed skill use splits by tool, not by model family**: left alone, `cursor` (Grok 4.5) and `codex` (GPT-5.x) reach for 7–8 skills a run, while every `claude-code` model settles around 3 — more than double on the Cursor/Codex side. Second, **skills and agents are separate reflexes**: `codex` pulls plenty of skills but never once spawns a sub-agent unprompted (0 / 23), whereas `cursor` with Grok delegates in about half its runs and `claude-code` with Fable every time on a tiny sample. The one- and two-run rows (Composer, Opus 5, Fable 5) are too thin to lean on; the Grok 4.5, GPT-5.x and Sonnet 5 rows carry the weight. All six S5 "≥1 agent" counts add up to the 17 self-directed-agent runs noted below.
 
 There is a caveat that keeps S5 from being a pure "no-agent control": **17 of 68** retained S5 runs still reached for at least one agent on their own initiative (11 on Problem 1, 6 on Problem 2). So the contrast is really *mandated* full orchestration versus *optional* self-directed tool use, not orchestration versus nothing.
+
+### Which skills get pulled in, per problem
+
+The pooled "6.0 vs 14.2" gap has a specific shape once it is split by problem and the skills are lined up by how often they appear. Each table counts **retained runs that pulled the skill in at least once** — the JSON records skills as a per-run set, so this is run frequency, not invocation count — sorted by the combined S4 + S5 total. The cohorts are the same trimmed ones used everywhere else in this section.
+
+**Problem 1 — God Analysis API (Spring Boot).** S4 `n = 18`, S5 `n = 30`.
+
+<table>
+<thead>
+<tr><th>Skill</th><th>S4 runs</th><th>S5 runs</th><th>Total</th></tr>
+</thead>
+<tbody>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/300-frameworks-spring-boot-create-project"><code>300-frameworks-spring-boot-create-project</code></a></td><td>17</td><td>23</td><td>40</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/302-frameworks-spring-boot-rest"><code>302-frameworks-spring-boot-rest</code></a></td><td>17</td><td>20</td><td>37</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/707-technologies-hexagonal-architecture"><code>707-technologies-hexagonal-architecture</code></a></td><td>13</td><td>24</td><td>37</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/323-frameworks-spring-boot-testing-acceptance-tests"><code>323-frameworks-spring-boot-testing-acceptance-tests</code></a></td><td>16</td><td>19</td><td>35</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/322-frameworks-spring-boot-testing-integration-tests"><code>322-frameworks-spring-boot-testing-integration-tests</code></a></td><td>15</td><td>17</td><td>32</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/702-technologies-wiremock"><code>702-technologies-wiremock</code></a></td><td>16</td><td>15</td><td>31</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/301-frameworks-spring-boot-core"><code>301-frameworks-spring-boot-core</code></a></td><td>16</td><td>13</td><td>29</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/321-frameworks-spring-boot-testing-unit-tests"><code>321-frameworks-spring-boot-testing-unit-tests</code></a></td><td>15</td><td>12</td><td>27</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/042-planning-openspec"><code>042-planning-openspec</code></a></td><td><strong>18</strong></td><td>6</td><td>24</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/125-java-concurrency"><code>125-java-concurrency</code></a></td><td>9</td><td>10</td><td>19</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/701-technologies-openapi"><code>701-technologies-openapi</code></a></td><td><strong>16</strong></td><td>3</td><td>19</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/303-frameworks-spring-boot-validation"><code>303-frameworks-spring-boot-validation</code></a></td><td>12</td><td>6</td><td>18</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/124-java-secure-coding"><code>124-java-secure-coding</code></a></td><td><strong>14</strong></td><td>1</td><td>15</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/126-java-exception-handling"><code>126-java-exception-handling</code></a></td><td>10</td><td>1</td><td>11</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/111-java-maven-dependencies"><code>111-java-maven-dependencies</code></a></td><td>3</td><td><strong>7</strong></td><td>10</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/122-java-type-design"><code>122-java-type-design</code></a></td><td>8</td><td>1</td><td>9</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/051-design-two-steps-methods"><code>051-design-two-steps-methods</code></a></td><td>4</td><td>3</td><td>7</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/110-java-maven-best-practices"><code>110-java-maven-best-practices</code></a></td><td>4</td><td>3</td><td>7</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/181-java-observability-logging"><code>181-java-observability-logging</code></a></td><td>7</td><td>0</td><td>7</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/054-design-tdd"><code>054-design-tdd</code></a></td><td>4</td><td>2</td><td>6</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/121-java-object-oriented-design"><code>121-java-object-oriented-design</code></a></td><td>6</td><td>0</td><td>6</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/130-java-testing-strategies"><code>130-java-testing-strategies</code></a></td><td>5</td><td>1</td><td>6</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/133-java-testing-acceptance-tests"><code>133-java-testing-acceptance-tests</code></a></td><td>0</td><td>6</td><td>6</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/112-java-maven-plugins"><code>112-java-maven-plugins</code></a></td><td>2</td><td>1</td><td>3</td></tr>
+<tr><td colspan="4"><em>tail (total ≤ 2): <a href="https://www.skills.sh/jabrena/plinth/143-java-functional-exception-handling"><code>143-java-functional-exception-handling</code></a> (2/0), <a href="https://www.skills.sh/jabrena/plinth/142-java-functional-programming"><code>142-java-functional-programming</code></a> (1/0), <a href="https://www.skills.sh/jabrena/plinth/052-design-hamburger-method"><code>052-design-hamburger-method</code></a> (1/0), <a href="https://www.skills.sh/jabrena/plinth/131-java-testing-unit-testing"><code>131-java-testing-unit-testing</code></a> (0/1), <a href="https://www.skills.sh/jabrena/plinth/132-java-testing-integration-testing"><code>132-java-testing-integration-testing</code></a> (0/1)</em></td></tr>
+</tbody>
+</table>
+
+The framework scaffold sits at the top and is used heavily by *both* cohorts — `create-project` (17/18 vs 23/30), `-rest`, the three `-testing-` skills, `wiremock` — because the OpenSpec plan names those technologies directly, so a direct implementer walks into them anyway. `707-…-hexagonal-architecture` is actually *more* common under S5 (24/30) than S4 (13/18): it is written into `design.md`, and the S4 tech-lead does not always re-log it.
+
+The divergence is entirely in the cross-cutting discipline skills. `042-planning-openspec` goes 18/18 → 6/30; `701-…-openapi` 16 → 3, `124-java-secure-coding` 14 → 1, `126-java-exception-handling` 10 → 1, `122-java-type-design` 8 → 1, `181-java-observability-logging` 7 → 0, `121-java-object-oriented-design` 6 → 0. The only skill S5 reaches for *more* than S4 is `111-java-maven-dependencies` (3 → 7) — implementing directly, the tool edits the POM itself instead of delegating it — and S5 grabs the generic `133-java-testing-acceptance-tests` (0 → 6) where S4 uses the Spring-specific `323-…`.
+
+**Problem 2 — Greek Gods API (Quarkus, persistence + scheduling).** S4 `n = 32`, S5 `n = 38`.
+
+<table>
+<thead>
+<tr><th>Skill</th><th>S4 runs</th><th>S5 runs</th><th>Total</th></tr>
+</thead>
+<tbody>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/707-technologies-hexagonal-architecture"><code>707-technologies-hexagonal-architecture</code></a></td><td>32</td><td>36</td><td>68</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/400-frameworks-quarkus-create-project"><code>400-frameworks-quarkus-create-project</code></a></td><td>30</td><td>29</td><td>59</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/423-frameworks-quarkus-testing-acceptance-tests"><code>423-frameworks-quarkus-testing-acceptance-tests</code></a></td><td>31</td><td>23</td><td>54</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/413-frameworks-quarkus-db-migrations-flyway"><code>413-frameworks-quarkus-db-migrations-flyway</code></a></td><td><strong>32</strong></td><td>21</td><td>53</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/411-frameworks-quarkus-jdbc"><code>411-frameworks-quarkus-jdbc</code></a></td><td>31</td><td>21</td><td>52</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/402-frameworks-quarkus-rest"><code>402-frameworks-quarkus-rest</code></a></td><td>31</td><td>19</td><td>50</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/401-frameworks-quarkus-core"><code>401-frameworks-quarkus-core</code></a></td><td>31</td><td>15</td><td>46</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/421-frameworks-quarkus-testing-unit-tests"><code>421-frameworks-quarkus-testing-unit-tests</code></a></td><td>31</td><td>10</td><td>41</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/042-planning-openspec"><code>042-planning-openspec</code></a></td><td><strong>32</strong></td><td>2</td><td>34</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/701-technologies-openapi"><code>701-technologies-openapi</code></a></td><td><strong>30</strong></td><td>3</td><td>33</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/704-technologies-sql"><code>704-technologies-sql</code></a></td><td><strong>26</strong></td><td>1</td><td>27</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/422-frameworks-quarkus-testing-integration-tests"><code>422-frameworks-quarkus-testing-integration-tests</code></a></td><td>19</td><td>7</td><td>26</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/126-java-exception-handling"><code>126-java-exception-handling</code></a></td><td><strong>20</strong></td><td>1</td><td>21</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/124-java-secure-coding"><code>124-java-secure-coding</code></a></td><td><strong>19</strong></td><td>0</td><td>19</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/111-java-maven-dependencies"><code>111-java-maven-dependencies</code></a></td><td>4</td><td><strong>13</strong></td><td>17</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/054-design-tdd"><code>054-design-tdd</code></a></td><td>13</td><td>0</td><td>13</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/133-java-testing-acceptance-tests"><code>133-java-testing-acceptance-tests</code></a></td><td>3</td><td>10</td><td>13</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/122-java-type-design"><code>122-java-type-design</code></a></td><td>11</td><td>0</td><td>11</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/121-java-object-oriented-design"><code>121-java-object-oriented-design</code></a></td><td>8</td><td>0</td><td>8</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/130-java-testing-strategies"><code>130-java-testing-strategies</code></a></td><td>8</td><td>0</td><td>8</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/123-java-design-patterns"><code>123-java-design-patterns</code></a></td><td>5</td><td>0</td><td>5</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/143-java-functional-exception-handling"><code>143-java-functional-exception-handling</code></a></td><td>4</td><td>0</td><td>4</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/110-java-maven-best-practices"><code>110-java-maven-best-practices</code></a></td><td>3</td><td>0</td><td>3</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/181-java-observability-logging"><code>181-java-observability-logging</code></a></td><td>3</td><td>0</td><td>3</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/702-technologies-wiremock"><code>702-technologies-wiremock</code></a></td><td>3</td><td>0</td><td>3</td></tr>
+<tr><td colspan="4"><em>tail (total ≤ 2): <a href="https://www.skills.sh/jabrena/plinth/052-design-hamburger-method"><code>052-design-hamburger-method</code></a> (1/0), <a href="https://www.skills.sh/jabrena/plinth/112-java-maven-plugins"><code>112-java-maven-plugins</code></a> (0/1)</em></td></tr>
+</tbody>
+</table>
+
+Same pattern, sharper. `707-…-hexagonal-architecture` is near-universal in both (32/32, 36/38) — contractual. The Quarkus scaffold and the persistence skills are used by both cohorts, but the gap is wider than on Problem 1: `413-…-flyway` 32/32 → 21/38, `423-…-acceptance-tests` 31 → 23, `421-…-unit-tests` 31 → 10. The pure-knowledge skills collapse outright: `704-technologies-sql` 26 → 1, `124-java-secure-coding` 19 → 0, `126-java-exception-handling` 20 → 1, `054-design-tdd` 13 → 0, `122-java-type-design` 11 → 0, and the `121`/`130`/`123` design skills 5–8 → 0. As on Problem 1, `111-java-maven-dependencies` is the lone skill S5 leans on harder (4 → 13). Self-directed agent use is rarer here too — 32 of 38 S5 runs used no agent at all, against 19 of 30 on Problem 1 — so on the harder problem the tools fall back to plain implementation even more.
+
+**Across both problems the split is the same.** Skills that name a *technology the plan already specifies* — framework create / rest / test, hexagonal architecture, Flyway, JDBC, WireMock — get used with or without the command. Skills that encode *cross-cutting practice* — `openspec` planning, `openapi`, secure-coding, exception-handling, type-design, TDD, OO / design-pattern, observability — are pulled in almost only when `/implement-spec` drives. That difference is what the "14.2 vs 6.0" is made of.
 
 **Hypothesis 2 is supported.** Autonomous skill and agent use tracks the delegation command, not the richness of the specification the agent is handed.
 
@@ -286,7 +385,6 @@ The hexagonal scaffold and the ArchUnit boundary test appear in 67 of 68 direct 
 The data points at a handful of concrete changes to `/implement-spec`, each tied to a finding above:
 
 1. **Cut the latency — scale orchestration to the task.** The full tech-lead + framework-coder fan-out runs on every task, but the rework payoff only lands on the integration-heavy problem; on Problem 1 it buys nothing and still costs ~36% more wall time and more than twice the wall-time-outlier rate. Grade the task up front — integration count, persistence, migrations, concurrency, external services — and run the full fan-out only above a threshold. Below it, a single implementation pass plus one verification checkpoint should match it for far less time.
-2. **Find and keep only the active ingredient.** An S4 run pulls ~14 skills and 2 agents; the correction-rate benefit may come from a single verification pass. Log which sub-step fired and what each one caught, then drop — or background — the steps that never move rework.
 
 ## Share your insights
 

--- a/site-generator/content/blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.md
+++ b/site-generator/content/blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.md
@@ -6,7 +6,7 @@ author=MyRobot
 status=published
 ~~~~~~
 
-This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. In [Part 1](https://jabrena.github.io/plinth/blog/2026/07/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-1.html) article, it showed the [benchmark](https://github.com/jabrena/plinth/tree/main/benchmarks) results around 4 scenarios:
+This is the second article in a series that tries to put a number on the value of Plinth's AI-native development workflow for Java. The [Part 1](https://jabrena.github.io/plinth/blog/2026/07/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-1.html) article showed the [benchmark](https://github.com/jabrena/plinth/tree/main/benchmarks) results across 4 scenarios:
 
 <table>
 <thead>
@@ -20,7 +20,7 @@ This is the second article in a series that tries to put a number on the value o
 </tbody>
 </table>
 
-The benchmark tried to validate the followed Hyphoteses:
+The benchmark tried to validate the following hypotheses:
 
 - **Hypothesis 1:** Richer workflows reduce implementation rework.
 - **Hypothesis 2:** Delegation workflows encourage autonomous use of reusable skills.
@@ -55,18 +55,18 @@ Two additions to the harness: a new scenario, and a second problem.
 <tr><th>Problem</th><th>What it is</th></tr>
 </thead>
 <tbody>
-<tr><td><a href="https://github.com/jabrena/plinth/tree/main/benchmarks/problem1">Problem 1</a> — God Analysis API</td><td>The original benchmark problem (<a href="https://github.com/jabrena/latency-problems/blob/master/docs/problem1/README.md">latency-problems Problem 1</a>): a REST API that fans out to a third-party service and aggregates the results. A pure <strong>fan-out-and-sum</strong> problem, carried over from Part 1.</td></tr>
-<tr><td><a href="https://github.com/jabrena/plinth/tree/main/benchmarks/problem2">Problem 2</a> — Greek Gods API</td><td>New in Part 2 (<a href="https://github.com/jabrena/latency-problems/blob/master/docs/problem5/README.md">latency-problems Problem 5</a>): a REST API that periodically syncs a Greek-gods catalogue from a third-party service into a relational database via Flyway. A <strong>persistence-and-scheduling</strong> problem, not a pure fan-out-and-sum one.</td></tr>
+<tr><td><a href="https://github.com/jabrena/plinth/tree/main/benchmarks/problem1">Problem 1</a> — God Analysis API</td><td>The original benchmark problem (<a href="https://github.com/jabrena/latency-problems/blob/master/docs/problem1/README.md">latency-problems Problem 1</a>): a <strong>Spring Boot</strong> REST API that fans out to a third-party service and aggregates the results. A pure <strong>fan-out-and-sum</strong> problem, carried over from Part 1.</td></tr>
+<tr><td><a href="https://github.com/jabrena/plinth/tree/main/benchmarks/problem2">Problem 2</a> — Greek Gods API</td><td>New in Part 2 (<a href="https://github.com/jabrena/latency-problems/blob/master/docs/problem5/README.md">latency-problems Problem 5</a>): a <strong>Quarkus</strong> REST API that periodically syncs a Greek-gods catalogue from a third-party service into a relational database via Flyway. A <strong>persistence-and-scheduling</strong> problem, not a pure fan-out-and-sum one.</td></tr>
 </tbody>
 </table>
 
 So `scenario4` (**S4**, orchestrated) versus `scenario5` (**S5**, direct) is a clean A/B: identical plan, and the only difference is whether `/implement-spec` and its agents run. Running that A/B across both problems shows whether the answer is problem-dependent.
 
-The dataset has also grown a lot — from the 54 runs in Part 1 to **217 non-template result records** across both problems, five scenarios, and tools including `cursor`, `codex`, `claude-code`, and `github-copilot` on a spread of models (Grok 4.5, GPT-5.x, Claude Sonnet 5 / Opus 5 / Fable 5, Composer).
+Part 2 runs the benchmark on **Plinth v0.18.0**; Part 1 used **Plinth v0.17.0**.
 
 ### How long the two problems actually take
 
-Those fences come from the full per-problem wall-clock distribution — every scenario, tool, and model pooled together. It is worth looking at that distribution on its own, because it answers the question people ask before they ask anything about workflows: *how long is one of these runs?*
+The Tukey fences below come from the full per-problem wall-clock distribution — every scenario, tool, and model pooled together. It is worth looking at that distribution on its own, because it answers the question people ask before they ask anything about workflows: *how long is one of these runs?*
 
 <table>
 <thead>
@@ -339,9 +339,122 @@ On **Problem 1** the two workflows land within half a test class of each other. 
 
 The usual caveat applies: this is **file presence**. A `*Test.java` in the tree is not proof it compiles, runs, or asserts anything — the single acceptance flag is still the only execution signal in the dataset.
 
+**Which testing skills each harness reaches for.** The per-problem skill tables earlier in this section pool all three tools. Splitting the **same trimmed S4/S5 cohorts** by harness — and keeping only the skills whose name marks them as test work (`*-testing-*`, `054-design-tdd`, `702-technologies-wiremock`) — shows each tool has its own testing-skill reflex once `/implement-spec` is out of the picture. The `claude-code` rows are restricted to **Sonnet 5** samples (the Opus 5 / Fable 5 runs are 1–5 apiece, too thin to read); `codex` is all GPT-5.x and `cursor` is Grok 4.5 plus a little Composer. Every cell counts **retained runs that pulled the skill in at least once**, sorted by the combined S4 + S5 total.
+
+#### `claude-code` (Sonnet 5)
+
+**Problem 1 — God Analysis API (Spring Boot).** S4 `n = 3`, S5 `n = 8`.
+
+<table>
+<thead>
+<tr><th>Testing skill</th><th>S4 runs</th><th>S5 runs</th><th>Total</th></tr>
+</thead>
+<tbody>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/323-frameworks-spring-boot-testing-acceptance-tests"><code>323-frameworks-spring-boot-testing-acceptance-tests</code></a></td><td>3</td><td>4</td><td>7</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/702-technologies-wiremock"><code>702-technologies-wiremock</code></a></td><td>3</td><td>4</td><td>7</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/321-frameworks-spring-boot-testing-unit-tests"><code>321-frameworks-spring-boot-testing-unit-tests</code></a></td><td>3</td><td>3</td><td>6</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/322-frameworks-spring-boot-testing-integration-tests"><code>322-frameworks-spring-boot-testing-integration-tests</code></a></td><td>3</td><td>3</td><td>6</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/130-java-testing-strategies"><code>130-java-testing-strategies</code></a></td><td>1</td><td>0</td><td>1</td></tr>
+</tbody>
+</table>
+
+**Problem 2 — Greek Gods API (Quarkus).** S4 `n = 10`, S5 `n = 10`.
+
+<table>
+<thead>
+<tr><th>Testing skill</th><th>S4 runs</th><th>S5 runs</th><th>Total</th></tr>
+</thead>
+<tbody>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/423-frameworks-quarkus-testing-acceptance-tests"><code>423-frameworks-quarkus-testing-acceptance-tests</code></a></td><td>10</td><td>2</td><td>12</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/421-frameworks-quarkus-testing-unit-tests"><code>421-frameworks-quarkus-testing-unit-tests</code></a></td><td>10</td><td>0</td><td>10</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/130-java-testing-strategies"><code>130-java-testing-strategies</code></a></td><td>2</td><td>0</td><td>2</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/054-design-tdd"><code>054-design-tdd</code></a></td><td>1</td><td>0</td><td>1</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/422-frameworks-quarkus-testing-integration-tests"><code>422-frameworks-quarkus-testing-integration-tests</code></a></td><td>1</td><td>0</td><td>1</td></tr>
+</tbody>
+</table>
+
+Under orchestration Sonnet 5 logs the framework testing trio (unit / integration / acceptance) in every run; strip the command and almost all of it disappears. On Problem 2 the only testing skill any direct Sonnet 5 run records is `423-…-acceptance-tests`, in 2 of 10 — the sparse self-directed profile seen everywhere else for this tool.
+
+#### `codex` (GPT-5.x)
+
+**Problem 1 — God Analysis API (Spring Boot).** S4 `n = 3`, S5 `n = 9`.
+
+<table>
+<thead>
+<tr><th>Testing skill</th><th>S4 runs</th><th>S5 runs</th><th>Total</th></tr>
+</thead>
+<tbody>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/322-frameworks-spring-boot-testing-integration-tests"><code>322-frameworks-spring-boot-testing-integration-tests</code></a></td><td>3</td><td>5</td><td>8</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/323-frameworks-spring-boot-testing-acceptance-tests"><code>323-frameworks-spring-boot-testing-acceptance-tests</code></a></td><td>3</td><td>5</td><td>8</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/133-java-testing-acceptance-tests"><code>133-java-testing-acceptance-tests</code></a></td><td>0</td><td>5</td><td>5</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/321-frameworks-spring-boot-testing-unit-tests"><code>321-frameworks-spring-boot-testing-unit-tests</code></a></td><td>3</td><td>1</td><td>4</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/702-technologies-wiremock"><code>702-technologies-wiremock</code></a></td><td>3</td><td>0</td><td>3</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/130-java-testing-strategies"><code>130-java-testing-strategies</code></a></td><td>2</td><td>0</td><td>2</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/054-design-tdd"><code>054-design-tdd</code></a></td><td>0</td><td>1</td><td>1</td></tr>
+</tbody>
+</table>
+
+**Problem 2 — Greek Gods API (Quarkus).** S4 `n = 10`, S5 `n = 14`.
+
+<table>
+<thead>
+<tr><th>Testing skill</th><th>S4 runs</th><th>S5 runs</th><th>Total</th></tr>
+</thead>
+<tbody>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/423-frameworks-quarkus-testing-acceptance-tests"><code>423-frameworks-quarkus-testing-acceptance-tests</code></a></td><td>9</td><td>11</td><td>20</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/422-frameworks-quarkus-testing-integration-tests"><code>422-frameworks-quarkus-testing-integration-tests</code></a></td><td>9</td><td>6</td><td>15</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/421-frameworks-quarkus-testing-unit-tests"><code>421-frameworks-quarkus-testing-unit-tests</code></a></td><td>9</td><td>5</td><td>14</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/133-java-testing-acceptance-tests"><code>133-java-testing-acceptance-tests</code></a></td><td>3</td><td>10</td><td>13</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/130-java-testing-strategies"><code>130-java-testing-strategies</code></a></td><td>4</td><td>0</td><td>4</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/054-design-tdd"><code>054-design-tdd</code></a></td><td>3</td><td>0</td><td>3</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/702-technologies-wiremock"><code>702-technologies-wiremock</code></a></td><td>2</td><td>0</td><td>2</td></tr>
+</tbody>
+</table>
+
+`codex` keeps reaching for testing skills without the command — but it drifts from the framework-specific `323`/`423` toward the generic `133-java-testing-acceptance-tests` (0 → 5 on Problem 1, 3 → 10 on Problem 2). Unit- and integration-testing skills survive into S5 at a reduced rate, while the practice skills (`130`, `054-design-tdd`, `702-technologies-wiremock`) fall to zero.
+
+#### `cursor` (Grok 4.5 / Composer)
+
+**Problem 1 — God Analysis API (Spring Boot).** S4 `n = 9`, S5 `n = 11`.
+
+<table>
+<thead>
+<tr><th>Testing skill</th><th>S4 runs</th><th>S5 runs</th><th>Total</th></tr>
+</thead>
+<tbody>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/702-technologies-wiremock"><code>702-technologies-wiremock</code></a></td><td>8</td><td>10</td><td>18</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/323-frameworks-spring-boot-testing-acceptance-tests"><code>323-frameworks-spring-boot-testing-acceptance-tests</code></a></td><td>8</td><td>9</td><td>17</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/322-frameworks-spring-boot-testing-integration-tests"><code>322-frameworks-spring-boot-testing-integration-tests</code></a></td><td>7</td><td>9</td><td>16</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/321-frameworks-spring-boot-testing-unit-tests"><code>321-frameworks-spring-boot-testing-unit-tests</code></a></td><td>7</td><td>8</td><td>15</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/054-design-tdd"><code>054-design-tdd</code></a></td><td>4</td><td>1</td><td>5</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/130-java-testing-strategies"><code>130-java-testing-strategies</code></a></td><td>1</td><td>1</td><td>2</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/131-java-testing-unit-testing"><code>131-java-testing-unit-testing</code></a></td><td>0</td><td>1</td><td>1</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/132-java-testing-integration-testing"><code>132-java-testing-integration-testing</code></a></td><td>0</td><td>1</td><td>1</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/133-java-testing-acceptance-tests"><code>133-java-testing-acceptance-tests</code></a></td><td>0</td><td>1</td><td>1</td></tr>
+</tbody>
+</table>
+
+**Problem 2 — Greek Gods API (Quarkus).** S4 `n = 11`, S5 `n = 11`.
+
+<table>
+<thead>
+<tr><th>Testing skill</th><th>S4 runs</th><th>S5 runs</th><th>Total</th></tr>
+</thead>
+<tbody>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/423-frameworks-quarkus-testing-acceptance-tests"><code>423-frameworks-quarkus-testing-acceptance-tests</code></a></td><td>11</td><td>9</td><td>20</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/421-frameworks-quarkus-testing-unit-tests"><code>421-frameworks-quarkus-testing-unit-tests</code></a></td><td>11</td><td>5</td><td>16</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/422-frameworks-quarkus-testing-integration-tests"><code>422-frameworks-quarkus-testing-integration-tests</code></a></td><td>8</td><td>1</td><td>9</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/054-design-tdd"><code>054-design-tdd</code></a></td><td>8</td><td>0</td><td>8</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/130-java-testing-strategies"><code>130-java-testing-strategies</code></a></td><td>2</td><td>0</td><td>2</td></tr>
+<tr><td><a href="https://www.skills.sh/jabrena/plinth/702-technologies-wiremock"><code>702-technologies-wiremock</code></a></td><td>1</td><td>0</td><td>1</td></tr>
+</tbody>
+</table>
+
+`cursor` is the steadiest of the three. On Problem 1 the Spring testing trio plus `702-technologies-wiremock` appear at near-identical rates with and without the command. On Problem 2 direct runs still hold onto acceptance and unit testing, but `054-design-tdd` (8 → 0) and integration testing (8 → 1) are the ones that only survive under orchestration.
+
 ### Where orchestration does leave a fingerprint: the Maven build
 
-Architecture is contractual, but the `pom.xml` is not fully specified, and that is where the two workflows differ — a little. Decoding and parsing every retained Problem 2 POM (all 70 are strict-Base64, well-formed XML, Java 25, and import the Quarkus BOM):
+Architecture is contractual, but the `pom.xml` is not fully specified, and that is where the two workflows differ — a little. Decoding and parsing every retained Problem 2 POM (all 70 are strict-Base64, well-formed XML, Java 25, and import the Quarkus BOM) gives:
 
 <table>
 <thead>
@@ -353,13 +466,14 @@ Architecture is contractual, but the `pom.xml` is not fully specified, and that 
 <tr><td><code>quarkus</code> application packaging (rest are <code>jar</code>)</td><td>18/32</td><td>21/38</td></tr>
 <tr><td>SmallRye OpenAPI dependency</td><td>31/32</td><td>30/38</td></tr>
 <tr><td>ArchUnit dependency</td><td>32/32</td><td>37/38</td></tr>
-<tr><td>Native-build profile</td><td>15/32</td><td>18/38</td></tr>
 <tr><td>Custom repositories / multi-module</td><td>0/32</td><td>0/38</td></tr>
-<tr><td>Production / test / error-named Java files (means)</td><td>16.3 / 6.5 / 3.7</td><td>15.5 / 5.7 / 3.2</td></tr>
+<tr><td>Production Java files (mean per run)</td><td>16.3</td><td>15.5</td></tr>
+<tr><td>Test Java files (mean per run)</td><td>6.5</td><td>5.7</td></tr>
+<tr><td>Error-handling classes — name contains <code>Error</code>/<code>Exception</code> (mean per run)</td><td>3.7</td><td>3.2</td></tr>
 </tbody>
 </table>
 
-S4 pins the full Compiler / Surefire / Failsafe / Quarkus plugin set a bit more often (28/32 vs 26/38) and writes marginally more production and test files — a **5–15% edge**, not the large "assurance surface" gap an earlier read of the data suggested, and file presence still says nothing about whether those tests execute. On everything else the two are within a rounding error of each other. Packaging is a coin flip in *both* workflows: only about half of each cohort ships a `quarkus` application POM, the rest fall back to plain `jar`.
+S4 pins the full Compiler / Surefire / Failsafe / Quarkus plugin set a bit more often (28/32 vs 26/38) and writes marginally more production and test files — a **5–15% edge**, not the large "assurance surface" gap an earlier read of the data suggested, and file presence still says nothing about whether those tests execute. On everything else the two are within a rounding error of each other. Packaging is a coin flip in *both* workflows: only about half of each cohort ships a `quarkus` application POM; the rest fall back to plain `jar`.
 
 The bigger story in the POMs is drift that neither workflow controls. Retained Quarkus platform versions span **3.27.0 to 3.39.1**, and same-commit S4/S5 pairs sometimes pick different platform versions. A recurring set of POMs declares both `quarkus-rest` and `quarkus-rest-jackson`, or adds `quarkus-agroal` next to a JDBC driver that already pulls it in; several mix `quarkus-junit` with the older `quarkus-junit5-*` coordinate family. None of that is caused by the workflow — it is the agents choosing dependencies run to run — but it is exactly the kind of variance a benchmark has to normalize before it can compare anything downstream.
 
@@ -384,7 +498,7 @@ The hexagonal scaffold and the ArchUnit boundary test appear in 67 of 68 direct 
 
 The data points at a handful of concrete changes to `/implement-spec`, each tied to a finding above:
 
-1. **Cut the latency — scale orchestration to the task.** The full tech-lead + framework-coder fan-out runs on every task, but the rework payoff only lands on the integration-heavy problem; on Problem 1 it buys nothing and still costs ~36% more wall time and more than twice the wall-time-outlier rate. Grade the task up front — integration count, persistence, migrations, concurrency, external services — and run the full fan-out only above a threshold. Below it, a single implementation pass plus one verification checkpoint should match it for far less time.
+1. **Cut the latency.** Running the full agent fan-out on every job makes S4 about 36% slower than plain implementation (roughly 16 vs 10 minutes), and that extra time only earns its keep on hard, integration-heavy work. For simple problems, skip the fan-out and do one implementation pass plus one review — same result, much faster.
 
 ## Share your insights
 


### PR DESCRIPTION
## Summary

Adds the second article in the benchmark series that puts a number on the value of Plinth's AI-native development workflow for Java.

- Introduces a `scenario5` A/B that runs the **same** OpenSpec technical plan as `scenario4` implemented directly, isolating the `/implement-spec` command from the plan itself
- Adds a second problem (persistence-and-scheduling "Greek Gods API") so every finding can be read per problem
- Re-tests all three hypotheses on the expanded corpus (54 → 217 non-template records)

## Changes

- New source: `site-generator/content/blog/2026/09/validating-hypotheses-about-plinth-workflow-with-a-benchmark-part-2.md`
- Regenerated `docs/` site output via `./mvnw clean generate-resources -pl site-generator -P site-update` (index, pagination, archive, feed, sitemap, tag pages, new post page)

## Validation

- `./mvnw clean generate-resources -pl site-generator -P site-update` — docs/ diff reviewed, all changes trace to the new post

🤖 Generated with [Claude Code](https://claude.com/claude-code)