### PR TITLE
docs(conferences): retitle JCConf 2026 deck to Harness Engineering with Java

### DIFF
--- a/documentation/conferences/jcconf-2026/index.html
+++ b/documentation/conferences/jcconf-2026/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 
-    <title>JCConf 2026 - AI-Native Java Engineering</title>
+    <title>JCConf 2026 - Harness Engineering with Java</title>
 
     <link rel="stylesheet" href="dist/reset.css">
     <link rel="stylesheet" href="dist/reveal.css">
@@ -25,7 +25,7 @@
             <section data-background-image="./images/pillars2.jpg">
                 <h1>
                     <span style="display: inline-block; color: black; background: #ffffff;">
-                        AI-Native Java Engineering
+                        利用 Java 进行工程实践
                     </span>
                 </h1>
                 <p>


### PR DESCRIPTION
## Summary

- Update the JCConf 2026 slide deck `<title>` from "AI-Native Java Engineering" to "Harness Engineering with Java"
- Update the opening slide heading to the localized "利用 Java 进行工程实践"

## Notes

Documentation-only change to `documentation/conferences/jcconf-2026/index.html`. No build or generator impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)