### PR TITLE
docs(conferences): polish JCConf 2026 deck copy and add contract-testing reference

### DIFF
--- a/docs/feed.xml
+++ b/docs/feed.xml
@@ -2,7 +2,7 @@
 <feed xmlns='http://www.w3.org/2005/Atom' xml:lang='en'>
   <id>https://jabrena.github.io/plinth/</id>
   <title>Plinth</title>
-  <updated>2026-09-10T12:11:46+0800</updated>
+  <updated>2026-09-10T22:11:10+0800</updated>
   <link rel="alternate" type="text/html" href="https://jabrena.github.io/plinth/" />
   <link rel='self' type='application/atom+xml' href='https://jabrena.github.io/plinth//feed.xml' />
   <entry>

--- a/docs/jcconf-2026/index.html
+++ b/docs/jcconf-2026/index.html
@@ -59,7 +59,7 @@
                         <tr>
                             <td colspan="2" align="center" style="color: #336699;">
                                 <em>"Make it work, make it right, make it fast." <br />- Kent Beck</em><br />
-                                <em>"Lead me, follow me, or get out of my way.", <br />"Pressure makes diamonds."
+                                <em>"Lead me, follow me, or get out of my way." <br />"Pressure makes diamonds."
                                     <br />- George S. Patton Jr.</em>
                             </td>
                         </tr>
@@ -118,8 +118,8 @@
                     <h2>Introduction</h2>
                     <p>
                         The usage of AI in software engineering
-                        is changing <strong>the way of work</strong> but with the change
-                        appear new challeges to address.
+                        is changing <strong>the way we work</strong>, but that change
+                        brings new challenges to address.
                     </p>
                     <img src="./images/SDLC.jpg" width="35%" />
                 </section>
@@ -285,7 +285,7 @@
                 </section>
 
                 <section>
-                    <h2>Good specifications  requires time</h2>
+                    <h2>Good specifications require time</h2>
                     <p>
                         AI makes <span class="evidence">implementation 10&times; faster</span>.<br />
                         Understanding intent, constraints, and consequences still runs at <span class="risk">1&times;</span>.
@@ -294,18 +294,22 @@
                 </section>
 
                 <section>
-                    <h2>Agile three amigos is not a Movie!</h2>
+                    <h2>The Three Amigos!</h2>
                     <p>
-                        <img src="./images/three-amigos.png" width="40%" />
+                        <img src="./images/three-amigos.png" width="30%" /><br />
+                        <small>
+                            <strong>Source: </strong><a href="https://www.imdb.com/es-es/title/tt0092086/"
+                                target="_blank">https://www.imdb.com/es-es/title/tt0092086/</a>
+                        </small>
                     </p>
                     <p>
-                        The Three Amigos is a practice where three perspectives review an increment of
+                        The Three Amigos is an Agile practice where three perspectives review an increment of
                         work before, during, and after development: <strong>Business</strong>, <strong>Development</strong> & <strong>Testing</strong>.
                     </p>
                 </section>
 
                 <section>
-                    <h2>Use the double loop Agile</h2>
+                    <h2>Use the Agile double-loop</h2>
                     <p>
                         <img src="./images/double-loop-agile.png" width="60%" />
                         <small>
@@ -315,8 +319,8 @@
                     </p>
                     <p>
                         Two loops run in parallel: discovery asks
-                        are we building the right thing? and delivery
-                        asks are we building it right?
+                        "are we building the right thing?" and delivery
+                        asks "are we building it right?"
                     </p>
                 </section>
 
@@ -424,8 +428,8 @@ record Order(String clientId, BigDecimal total) {}
 
                 <section class="section-divider bridge">
                     <p class="statement">
-                        How to improve the development experience 
-                        using AI Harness engineering at scale? 🤔
+                        How do we improve the developer experience
+                        with AI Harness Engineering at scale? 🤔
                     </p>
                 </section>
             </section>
@@ -547,19 +551,20 @@ record Order(String clientId, BigDecimal total) {}
                 <section>
                     <h2>What can a team do next Monday?</h2>
                     <ul>
-                        <li>Review if your service databases has Migration scripts</li>
-                        <li>Review if service communications use Contracts (OpenAPI, AVRO, etc...) and they are governed.</li>
-                        <li>Review in what way your developments reuse patterns, components and patterns in your Domains.</li>
-                        <li>Review if your teams are using monorepos to facilitate the AI-agent harness.</li>
+                        <li>Review whether your service databases have migration scripts.</li>
+                        <li>Review if team know and use Parallel Change pattern</li>
+                        <li>Review whether service communications use governed contracts (OpenAPI, Avro, etc.).</li>
+                        <li>Review how your projects reuse patterns, components, and practices across your domains.</li>
                     </ul>
                 </section>
                 <section>
                     <h2>What can a team do next Monday?</h2>
                     <ul>
-                        <li>Review if your Software engineers are using common Skills?</li>
-                        <li>Review if your Squads use SDD or they require a specific training.</li>
-                        <li>Review to Engineer the workflow, not just the prompt.</li>
-                        <li>Review to optimize for system awareness and system correctness.</li>
+                        <li>Review whether your teams are using monorepos to facilitate the AI-agent harness.</li>
+                        <li>Review whether your software engineers use common skills.</li>
+                        <li>Review whether your squads use SDD or need specific training.</li>
+                        <li>Engineer the workflow, not just the prompt.</li>
+                        <li>Optimize for system awareness and system correctness, not just local correctness.</li>
                     </ul>
                 </section>
             </section>
@@ -568,13 +573,11 @@ record Order(String clientId, BigDecimal total) {}
                 <h2>References</h2>
                 <ul>
                     <li><a href="https://github.com/jabrena/plinth" target="_blank">Plinth on GitHub</a></li>
-                    <li><a href="https://www.skills.sh/jabrena/plinth" target="_blank">Plinth skills on Skills.sh</a>
-                    </li>
+                    <li><a href="https://www.skills.sh/jabrena/plinth" target="_blank">Plinth skills on Skills.sh</a></li>
                     <li><a href="https://openspec.dev/" target="_blank">OpenSpec</a></li>
-                    <li><a href="https://modelcontextprotocol.io/introduction" target="_blank">Model Context
-                            Protocol</a></li>
-                    <li><a href="https://martinfowler.com/bliki/ParallelChange.html" target="_blank">Parallel Change</a>
-                    </li>
+                    <li><a href="https://modelcontextprotocol.io/introduction" target="_blank">Model Context Protocol</a></li>
+                    <li><a href="https://martinfowler.com/bliki/ParallelChange.html" target="_blank">Parallel Change</a></li>
+                    <li><a href="https://stubborn.sh/" target="_blank">Stubborn (Contract Testing)</a></li>
                 </ul>
             </section>
 

--- a/documentation/conferences/jcconf-2026/index.html
+++ b/documentation/conferences/jcconf-2026/index.html
@@ -59,7 +59,7 @@
                         <tr>
                             <td colspan="2" align="center" style="color: #336699;">
                                 <em>"Make it work, make it right, make it fast." <br />- Kent Beck</em><br />
-                                <em>"Lead me, follow me, or get out of my way.", <br />"Pressure makes diamonds."
+                                <em>"Lead me, follow me, or get out of my way." <br />"Pressure makes diamonds."
                                     <br />- George S. Patton Jr.</em>
                             </td>
                         </tr>
@@ -118,8 +118,8 @@
                     <h2>Introduction</h2>
                     <p>
                         The usage of AI in software engineering
-                        is changing <strong>the way of work</strong> but with the change
-                        appear new challeges to address.
+                        is changing <strong>the way we work</strong>, but that change
+                        brings new challenges to address.
                     </p>
                     <img src="./images/SDLC.jpg" width="35%" />
                 </section>
@@ -285,7 +285,7 @@
                 </section>
 
                 <section>
-                    <h2>Good specifications  requires time</h2>
+                    <h2>Good specifications require time</h2>
                     <p>
                         AI makes <span class="evidence">implementation 10&times; faster</span>.<br />
                         Understanding intent, constraints, and consequences still runs at <span class="risk">1&times;</span>.
@@ -294,18 +294,22 @@
                 </section>
 
                 <section>
-                    <h2>Agile three amigos is not a Movie!</h2>
+                    <h2>The Three Amigos!</h2>
                     <p>
-                        <img src="./images/three-amigos.png" width="40%" />
+                        <img src="./images/three-amigos.png" width="30%" /><br />
+                        <small>
+                            <strong>Source: </strong><a href="https://www.imdb.com/es-es/title/tt0092086/"
+                                target="_blank">https://www.imdb.com/es-es/title/tt0092086/</a>
+                        </small>
                     </p>
                     <p>
-                        The Three Amigos is a practice where three perspectives review an increment of
+                        The Three Amigos is an Agile practice where three perspectives review an increment of
                         work before, during, and after development: <strong>Business</strong>, <strong>Development</strong> & <strong>Testing</strong>.
                     </p>
                 </section>
 
                 <section>
-                    <h2>Use the double loop Agile</h2>
+                    <h2>Use the Agile double-loop</h2>
                     <p>
                         <img src="./images/double-loop-agile.png" width="60%" />
                         <small>
@@ -315,8 +319,8 @@
                     </p>
                     <p>
                         Two loops run in parallel: discovery asks
-                        are we building the right thing? and delivery
-                        asks are we building it right?
+                        "are we building the right thing?" and delivery
+                        asks "are we building it right?"
                     </p>
                 </section>
 
@@ -424,8 +428,8 @@ record Order(String clientId, BigDecimal total) {}
 
                 <section class="section-divider bridge">
                     <p class="statement">
-                        How to improve the development experience 
-                        using AI Harness engineering at scale? 🤔
+                        How do we improve the developer experience
+                        with AI Harness Engineering at scale? 🤔
                     </p>
                 </section>
             </section>
@@ -547,19 +551,20 @@ record Order(String clientId, BigDecimal total) {}
                 <section>
                     <h2>What can a team do next Monday?</h2>
                     <ul>
-                        <li>Review if your service databases has Migration scripts</li>
-                        <li>Review if service communications use Contracts (OpenAPI, AVRO, etc...) and they are governed.</li>
-                        <li>Review in what way your developments reuse patterns, components and patterns in your Domains.</li>
-                        <li>Review if your teams are using monorepos to facilitate the AI-agent harness.</li>
+                        <li>Review whether your service databases have migration scripts.</li>
+                        <li>Review if team know and use Parallel Change pattern</li>
+                        <li>Review whether service communications use governed contracts (OpenAPI, Avro, etc.).</li>
+                        <li>Review how your projects reuse patterns, components, and practices across your domains.</li>
                     </ul>
                 </section>
                 <section>
                     <h2>What can a team do next Monday?</h2>
                     <ul>
-                        <li>Review if your Software engineers are using common Skills?</li>
-                        <li>Review if your Squads use SDD or they require a specific training.</li>
-                        <li>Review to Engineer the workflow, not just the prompt.</li>
-                        <li>Review to optimize for system awareness and system correctness.</li>
+                        <li>Review whether your teams are using monorepos to facilitate the AI-agent harness.</li>
+                        <li>Review whether your software engineers use common skills.</li>
+                        <li>Review whether your squads use SDD or need specific training.</li>
+                        <li>Engineer the workflow, not just the prompt.</li>
+                        <li>Optimize for system awareness and system correctness, not just local correctness.</li>
                     </ul>
                 </section>
             </section>
@@ -568,13 +573,11 @@ record Order(String clientId, BigDecimal total) {}
                 <h2>References</h2>
                 <ul>
                     <li><a href="https://github.com/jabrena/plinth" target="_blank">Plinth on GitHub</a></li>
-                    <li><a href="https://www.skills.sh/jabrena/plinth" target="_blank">Plinth skills on Skills.sh</a>
-                    </li>
+                    <li><a href="https://www.skills.sh/jabrena/plinth" target="_blank">Plinth skills on Skills.sh</a></li>
                     <li><a href="https://openspec.dev/" target="_blank">OpenSpec</a></li>
-                    <li><a href="https://modelcontextprotocol.io/introduction" target="_blank">Model Context
-                            Protocol</a></li>
-                    <li><a href="https://martinfowler.com/bliki/ParallelChange.html" target="_blank">Parallel Change</a>
-                    </li>
+                    <li><a href="https://modelcontextprotocol.io/introduction" target="_blank">Model Context Protocol</a></li>
+                    <li><a href="https://martinfowler.com/bliki/ParallelChange.html" target="_blank">Parallel Change</a></li>
+                    <li><a href="https://stubborn.sh/" target="_blank">Stubborn (Contract Testing)</a></li>
                 </ul>
             </section>
 


### PR DESCRIPTION
## Summary

Copy-editing pass over the JCConf 2026 slide deck plus one new reference.

- Tighten wording across slides: introduction, "Good specifications require time", "The Three Amigos!", "Use the Agile double-loop", the two "What can a team do next Monday?" checklists, and the bridge statement.
- Fix small typos ("challeges", double spaces, stray comma).
- Add an IMDb source link for the Three Amigos image.
- Add the Stubborn (Contract Testing) reference to the References slide.
- Regenerate the published `docs/` output (`docs/jcconf-2026/index.html`, `docs/feed.xml`) alongside the source under `documentation/conferences/jcconf-2026/`.

## Validation

Docs-only change; no build required. Source and generated output committed together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)