### PR TITLE
docs(conferences): hide Agile double-loop slide in JCConf 2026 deck

### DIFF
--- a/docs/feed.xml
+++ b/docs/feed.xml
@@ -2,7 +2,7 @@
 <feed xmlns='http://www.w3.org/2005/Atom' xml:lang='en'>
   <id>https://jabrena.github.io/plinth/</id>
   <title>Plinth</title>
-  <updated>2026-09-10T22:11:10+0800</updated>
+  <updated>2026-09-11T07:57:28+0800</updated>
   <link rel="alternate" type="text/html" href="https://jabrena.github.io/plinth/" />
   <link rel='self' type='application/atom+xml' href='https://jabrena.github.io/plinth//feed.xml' />
   <entry>

--- a/docs/jcconf-2026/index.html
+++ b/docs/jcconf-2026/index.html
@@ -308,6 +308,7 @@
                     </p>
                 </section>
 
+                <!--
                 <section>
                     <h2>Use the Agile double-loop</h2>
                     <p>
@@ -323,6 +324,7 @@
                         asks "are we building it right?"
                     </p>
                 </section>
+                -->
 
                 <section>
                     <p class="statement"><span class="context">Specifications</span> solve task ambiguity.<br />They do

--- a/documentation/conferences/jcconf-2026/index.html
+++ b/documentation/conferences/jcconf-2026/index.html
@@ -308,6 +308,7 @@
                     </p>
                 </section>
 
+                <!--
                 <section>
                     <h2>Use the Agile double-loop</h2>
                     <p>
@@ -323,6 +324,7 @@
                         asks "are we building it right?"
                     </p>
                 </section>
+                -->
 
                 <section>
                     <p class="statement"><span class="context">Specifications</span> solve task ambiguity.<br />They do


### PR DESCRIPTION
## Summary

- Comment out the "Use the Agile double-loop" section in the JCConf 2026 deck source (`documentation/conferences/jcconf-2026/index.html`)
- Regenerate the site output (`docs/jcconf-2026/index.html`, `docs/feed.xml`)

## Testing

- Docs-only change; no build required

🤖 Generated with [Claude Code](https://claude.com/claude-code)